### PR TITLE
feat: deterministic blackboard compression for synthesis (Research Q3)

### DIFF
--- a/src/swarm/compression.py
+++ b/src/swarm/compression.py
@@ -1,0 +1,328 @@
+"""Deterministic blackboard compression for synthesis.
+
+Addresses Open Research Question #3: "What's the best strategy for
+selecting, ranking, or clustering entries to maximize information density
+in the synthesis prompt without losing critical details?"
+
+Current approach (curation.py): send ALL active entries grouped by document
+to an LLM for curation. This module adds a deterministic pre-ranking and
+diversity-aware selection step that runs BEFORE the LLM curation, ensuring
+the LLM sees the highest-signal, most diverse subset when context windows
+are tight.
+
+Zero LLM calls. Pure deterministic scoring and selection.
+"""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .blackboard import Blackboard
+from .models import Entry
+
+
+# ---------------------------------------------------------------------------
+# Entry scoring
+# ---------------------------------------------------------------------------
+
+# Type weights: analysis and calculation carry more synthesis value than raw
+# observations, which are abundant.
+_TYPE_WEIGHTS = {
+    "analysis": 1.0,
+    "calculation": 0.95,
+    "strategy": 0.80,
+    "observation": 0.50,
+    "gap": 0.60,
+    "contradiction": 0.85,
+}
+
+# Tags that boost priority
+_HIGH_VALUE_TAGS = {
+    "entity_resolution", "debt_sensor", "state_conversion",
+    "plan_coverage", "materiality:high",
+}
+
+_CONTENT_VALUE_PATTERNS = [
+    (re.compile(r"\$\s*[\d,]+(?:\.\d+)?"), 0.15),       # dollar amounts
+    (re.compile(r"\b\d+(?:\.\d+)?%"), 0.10),             # percentages
+    (re.compile(r"\b(?:Section|Article|Clause)\s+\d"), 0.10),  # legal refs
+    (re.compile(r"\b\d{1,2}/\d{1,2}/\d{2,4}\b"), 0.05),  # dates
+    (re.compile(r"\b(?:shall|must|may not|prohibited)\b", re.I), 0.08),  # obligations
+]
+
+
+@dataclass
+class ScoredEntry:
+    """An entry with its computed synthesis-relevance score."""
+    entry: Entry
+    type_score: float
+    content_density: float
+    tag_boost: float
+    cross_ref_score: float
+    source_diversity_bonus: float
+    composite: float
+
+
+def score_entry(
+    entry: Entry,
+    source_doc_set: set[str],
+    cross_ref_count: int = 0,
+) -> ScoredEntry:
+    """Score a single entry for synthesis relevance."""
+    # Type score
+    type_score = _TYPE_WEIGHTS.get(entry.type, 0.3)
+
+    # Content density: presence of specific values
+    content = entry.content or ""
+    density = 0.0
+    for pattern, weight in _CONTENT_VALUE_PATTERNS:
+        if pattern.search(content):
+            density += weight
+    density = min(1.0, density)
+
+    # Tag boost
+    tags = set(entry.tags or [])
+    tag_boost = 0.2 if tags & _HIGH_VALUE_TAGS else 0.0
+
+    # Cross-reference score: entries that support or are supported by others
+    # are more valuable (they're part of an evidence chain)
+    ref_count = len(entry.supports_entries or []) + len(entry.contradicts_entries or [])
+    cross_ref = min(0.3, ref_count * 0.05)
+
+    # Source diversity bonus: entries from underrepresented documents get a
+    # small boost to ensure we don't overweight any single source
+    source_diversity = 0.0
+    if entry.source and entry.source.document:
+        # If this is the only entry from its doc, it's more valuable
+        doc = entry.source.document
+        if doc in source_doc_set:
+            source_diversity = 0.05  # will be adjusted in batch scoring
+
+    # Confidence factor
+    conf_factor = min(1.0, entry.confidence) if entry.confidence > 0 else 0.5
+
+    composite = (
+        0.35 * type_score
+        + 0.20 * density
+        + 0.15 * tag_boost
+        + 0.15 * cross_ref
+        + 0.05 * source_diversity
+        + 0.10 * conf_factor
+    )
+
+    return ScoredEntry(
+        entry=entry,
+        type_score=round(type_score, 4),
+        content_density=round(density, 4),
+        tag_boost=round(tag_boost, 4),
+        cross_ref_score=round(cross_ref, 4),
+        source_diversity_bonus=round(source_diversity, 4),
+        composite=round(composite, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch scoring with diversity adjustment
+# ---------------------------------------------------------------------------
+
+def score_all_entries(blackboard: Blackboard) -> list[ScoredEntry]:
+    """Score all active entries, adjusted for source-document diversity."""
+    active = [e for e in blackboard.entries if e.status == "active"]
+    if not active:
+        return []
+
+    # Count entries per source document
+    doc_counts: dict[str, int] = {}
+    for e in active:
+        doc = e.source.document if e.source else "cross_cutting"
+        doc_counts[doc or "cross_cutting"] = doc_counts.get(doc or "cross_cutting", 0) + 1
+
+    total = len(active)
+    doc_set = set(doc_counts.keys())
+
+    # Cross-reference count per entry
+    cross_ref_map: dict[str, int] = {}
+    for e in active:
+        for ref_id in (e.supports_entries or []):
+            cross_ref_map[ref_id] = cross_ref_map.get(ref_id, 0) + 1
+        for ref_id in (e.contradicts_entries or []):
+            cross_ref_map[ref_id] = cross_ref_map.get(ref_id, 0) + 1
+
+    scored: list[ScoredEntry] = []
+    for e in active:
+        se = score_entry(e, doc_set, cross_ref_map.get(e.id, 0))
+
+        # Diversity adjustment: entries from overrepresented docs get penalized
+        doc = e.source.document if e.source else "cross_cutting"
+        doc_frac = doc_counts.get(doc or "cross_cutting", 0) / total
+        if doc_frac > 0.4:
+            # More than 40% of entries from one doc → slight penalty
+            penalty = (doc_frac - 0.4) * 0.15
+            se.source_diversity_bonus = max(0.0, se.source_diversity_bonus - penalty)
+        elif doc_frac < 0.1 and total > 10:
+            # Rare doc → bonus
+            se.source_diversity_bonus += 0.10
+
+        se.composite = round(
+            0.35 * se.type_score
+            + 0.20 * se.content_density
+            + 0.15 * se.tag_boost
+            + 0.15 * se.cross_ref_score
+            + 0.05 * se.source_diversity_bonus
+            + 0.10 * min(1.0, e.confidence if e.confidence > 0 else 0.5),
+            4,
+        )
+        scored.append(se)
+
+    return scored
+
+
+# ---------------------------------------------------------------------------
+# Compression strategies
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CompressionResult:
+    """Result of compressing a blackboard for synthesis."""
+    selected: list[ScoredEntry]       # entries to include in synthesis prompt
+    deferred: list[ScoredEntry]       # entries excluded due to budget
+    total_scored: int
+    target_count: int
+    actual_count: int
+    coverage_by_doc: dict[str, int]   # how many entries selected per doc
+    coverage_by_type: dict[str, int]  # how many entries selected per type
+    tokens_saved_estimate: int        # rough estimate of tokens saved
+
+
+def compress_for_synthesis(
+    blackboard: Blackboard,
+    *,
+    target_count: int = 500,
+    min_per_doc: int = 5,
+    ensure_types: bool = True,
+) -> CompressionResult:
+    """Select the highest-value entries for synthesis, respecting diversity.
+
+    Args:
+        blackboard: the blackboard to compress.
+        target_count: max entries to select.
+        min_per_doc: minimum entries to include per document (diversity floor).
+        ensure_types: if True, guarantees at least one entry per type present.
+
+    Returns:
+        CompressionResult with selected/deferred entries and coverage stats.
+    """
+    scored = score_all_entries(blackboard)
+    if not scored:
+        return CompressionResult(
+            selected=[], deferred=[], total_scored=0,
+            target_count=target_count, actual_count=0,
+            coverage_by_doc={}, coverage_by_type={},
+            tokens_saved_estimate=0,
+        )
+
+    # Sort by composite score descending
+    scored.sort(key=lambda s: s.composite, reverse=True)
+
+    # Phase 1: Diversity floor — guarantee min_per_doc per document
+    selected_ids: set[str] = set()
+    selected: list[ScoredEntry] = []
+    doc_entries: dict[str, list[ScoredEntry]] = {}
+    for se in scored:
+        doc = se.entry.source.document if se.entry.source else "cross_cutting"
+        doc_entries.setdefault(doc or "cross_cutting", []).append(se)
+
+    for doc, entries in doc_entries.items():
+        for se in entries[:min_per_doc]:
+            if se.entry.id not in selected_ids:
+                selected.append(se)
+                selected_ids.add(se.entry.id)
+
+    # Phase 2: Type diversity — ensure at least one entry per type
+    if ensure_types:
+        type_present = {se.entry.type for se in selected}
+        all_types = {se.entry.type for se in scored}
+        missing_types = all_types - type_present
+        for se in scored:
+            if not missing_types:
+                break
+            if se.entry.type in missing_types and se.entry.id not in selected_ids:
+                selected.append(se)
+                selected_ids.add(se.entry.id)
+                missing_types.discard(se.entry.type)
+
+    # Phase 3: Fill remaining slots by score
+    remaining_budget = target_count - len(selected)
+    if remaining_budget > 0:
+        for se in scored:
+            if remaining_budget <= 0:
+                break
+            if se.entry.id not in selected_ids:
+                selected.append(se)
+                selected_ids.add(se.entry.id)
+                remaining_budget -= 1
+
+    deferred = [se for se in scored if se.entry.id not in selected_ids]
+
+    # Coverage stats
+    coverage_doc: dict[str, int] = {}
+    coverage_type: dict[str, int] = {}
+    for se in selected:
+        doc = se.entry.source.document if se.entry.source else "cross_cutting"
+        coverage_doc[doc or "cross_cutting"] = coverage_doc.get(doc or "cross_cutting", 0) + 1
+        coverage_type[se.entry.type] = coverage_type.get(se.entry.type, 0) + 1
+
+    # Rough token estimate: ~4 chars per token, each entry ~300 chars average
+    tokens_saved = len(deferred) * 75  # ~75 tokens per deferred entry
+
+    return CompressionResult(
+        selected=selected,
+        deferred=deferred,
+        total_scored=len(scored),
+        target_count=target_count,
+        actual_count=len(selected),
+        coverage_by_doc=coverage_doc,
+        coverage_by_type=coverage_type,
+        tokens_saved_estimate=tokens_saved,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ranked entry list for the curation prompt
+# ---------------------------------------------------------------------------
+
+def ranked_entries_for_curation(
+    blackboard: Blackboard,
+    max_entries: int = 500,
+) -> list[Entry]:
+    """Return entries ranked by synthesis relevance, for use in curation.py.
+
+    Drop-in replacement for `active = [e for e in blackboard.entries if ...]`
+    that pre-filters by deterministic quality score.
+    """
+    result = compress_for_synthesis(blackboard, target_count=max_entries)
+    return [se.entry for se in result.selected]
+
+
+def compression_report(result: CompressionResult) -> dict:
+    """Human-readable compression report for diagnostics."""
+    return {
+        "total_scored": result.total_scored,
+        "selected": result.actual_count,
+        "deferred": len(result.deferred),
+        "target": result.target_count,
+        "tokens_saved_estimate": result.tokens_saved_estimate,
+        "coverage_by_doc": result.coverage_by_doc,
+        "coverage_by_type": result.coverage_by_type,
+        "top_10_scores": [
+            {
+                "id": se.entry.id,
+                "type": se.entry.type,
+                "composite": se.composite,
+                "doc": se.entry.source.document if se.entry.source else "",
+            }
+            for se in result.selected[:10]
+        ],
+    }

--- a/src/swarm/compression.py
+++ b/src/swarm/compression.py
@@ -91,14 +91,13 @@ def score_entry(
     ref_count = len(entry.supports_entries or []) + len(entry.contradicts_entries or [])
     cross_ref = min(0.3, ref_count * 0.05)
 
-    # Source diversity bonus: entries from underrepresented documents get a
-    # small boost to ensure we don't overweight any single source
+    # Source-diversity is assigned in batch scoring (score_all_entries), which
+    # has the per-document counts needed to reward under-represented sources
+    # and penalise over-represented ones. In isolation a single entry carries a
+    # neutral 0.0 — the previous `doc in source_doc_set` check was always true
+    # (source_doc_set is the set of all docs) and so added a constant to every
+    # entry, contributing nothing to ranking.
     source_diversity = 0.0
-    if entry.source and entry.source.document:
-        # If this is the only entry from its doc, it's more valuable
-        doc = entry.source.document
-        if doc in source_doc_set:
-            source_diversity = 0.05  # will be adjusted in batch scoring
 
     # Confidence factor
     conf_factor = min(1.0, entry.confidence) if entry.confidence > 0 else 0.5
@@ -226,43 +225,53 @@ def compress_for_synthesis(
     # Sort by composite score descending
     scored.sort(key=lambda s: s.composite, reverse=True)
 
-    # Phase 1: Diversity floor — guarantee min_per_doc per document
+    # target_count is a HARD cap — the synthesis prompt has a finite context
+    # budget, so no phase may push the selection past it. cap == 0 selects
+    # nothing.
+    cap = max(0, target_count)
     selected_ids: set[str] = set()
     selected: list[ScoredEntry] = []
+
+    def _take(se: ScoredEntry) -> bool:
+        if len(selected) >= cap or se.entry.id in selected_ids:
+            return False
+        selected.append(se)
+        selected_ids.add(se.entry.id)
+        return True
+
+    # Phase 1: Diversity floor — up to min_per_doc per document, allocated
+    # round-robin by within-doc rank so one dominant document cannot consume
+    # the whole cap before minor documents get represented. (scored is already
+    # sorted, so doc_entries lists are best-first.)
     doc_entries: dict[str, list[ScoredEntry]] = {}
     for se in scored:
         doc = se.entry.source.document if se.entry.source else "cross_cutting"
         doc_entries.setdefault(doc or "cross_cutting", []).append(se)
 
-    for doc, entries in doc_entries.items():
-        for se in entries[:min_per_doc]:
-            if se.entry.id not in selected_ids:
-                selected.append(se)
-                selected_ids.add(se.entry.id)
+    for rank in range(min_per_doc):
+        if len(selected) >= cap:
+            break
+        for entries in doc_entries.values():
+            if rank < len(entries):
+                _take(entries[rank])
+                if len(selected) >= cap:
+                    break
 
-    # Phase 2: Type diversity — ensure at least one entry per type
+    # Phase 2: Type diversity — ensure at least one entry per type, within cap
     if ensure_types:
         type_present = {se.entry.type for se in selected}
-        all_types = {se.entry.type for se in scored}
-        missing_types = all_types - type_present
+        missing_types = {se.entry.type for se in scored} - type_present
         for se in scored:
-            if not missing_types:
+            if not missing_types or len(selected) >= cap:
                 break
-            if se.entry.type in missing_types and se.entry.id not in selected_ids:
-                selected.append(se)
-                selected_ids.add(se.entry.id)
+            if se.entry.type in missing_types and _take(se):
                 missing_types.discard(se.entry.type)
 
     # Phase 3: Fill remaining slots by score
-    remaining_budget = target_count - len(selected)
-    if remaining_budget > 0:
-        for se in scored:
-            if remaining_budget <= 0:
-                break
-            if se.entry.id not in selected_ids:
-                selected.append(se)
-                selected_ids.add(se.entry.id)
-                remaining_budget -= 1
+    for se in scored:
+        if len(selected) >= cap:
+            break
+        _take(se)
 
     deferred = [se for se in scored if se.entry.id not in selected_ids]
 
@@ -274,8 +283,10 @@ def compress_for_synthesis(
         coverage_doc[doc or "cross_cutting"] = coverage_doc.get(doc or "cross_cutting", 0) + 1
         coverage_type[se.entry.type] = coverage_type.get(se.entry.type, 0) + 1
 
-    # Rough token estimate: ~4 chars per token, each entry ~300 chars average
-    tokens_saved = len(deferred) * 75  # ~75 tokens per deferred entry
+    # Token estimate from the ACTUAL deferred content (~4 chars per token),
+    # not a flat per-entry guess — entry sizes vary widely, so a constant
+    # would misreport savings on short- or long-entry blackboards.
+    tokens_saved = sum(len(se.entry.content or "") for se in deferred) // 4
 
     return CompressionResult(
         selected=selected,
@@ -297,10 +308,15 @@ def ranked_entries_for_curation(
     blackboard: Blackboard,
     max_entries: int = 500,
 ) -> list[Entry]:
-    """Return entries ranked by synthesis relevance, for use in curation.py.
+    """Return the top ``max_entries`` active entries ranked by synthesis
+    relevance.
 
-    Drop-in replacement for `active = [e for e in blackboard.entries if ...]`
-    that pre-filters by deterministic quality score.
+    This is a context-budget guard, NOT a replacement for curation.py's
+    exhaustive per-document enumeration. curation deliberately tries to surface
+    EVERY fact; pre-filtering defeats that. Use this only when the active set
+    is larger than a hard context budget can hold and some bounded loss is
+    unavoidable — feed the ranked subset to the LLM step instead of truncating
+    arbitrarily. When everything fits, pass the full active set to curation.
     """
     result = compress_for_synthesis(blackboard, target_count=max_entries)
     return [se.entry for se in result.selected]

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,262 @@
+"""Tests for deterministic blackboard compression (Open Research Question #3)."""
+from __future__ import annotations
+
+from src.swarm.blackboard import Blackboard
+from src.swarm.compression import (
+    CompressionResult,
+    ScoredEntry,
+    compress_for_synthesis,
+    compression_report,
+    ranked_entries_for_curation,
+    score_all_entries,
+    score_entry,
+)
+from src.swarm.models import Entry, EntrySource, WorkerRecord, gen_entry_id
+
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+def _mk(content: str, etype: str = "observation", doc: str = "test.docx",
+        confidence: float = 0.9, tags: list[str] | None = None,
+        supports: list[str] | None = None) -> Entry:
+    return Entry(
+        id=gen_entry_id(), type=etype, content=content,
+        source=EntrySource(document=doc, section="Full"),
+        created_by=WorkerRecord("w", "d", 0), confidence=confidence,
+        tags=tags or [], supports_entries=supports or [],
+    )
+
+
+# -----------------------------------------------------------------------
+# Entry scoring
+# -----------------------------------------------------------------------
+
+class TestScoreEntry:
+    def test_analysis_scores_higher_than_observation(self):
+        obs = _mk("plain fact", etype="observation")
+        ana = _mk("analysis conclusion", etype="analysis")
+        s_obs = score_entry(obs, {"test.docx"})
+        s_ana = score_entry(ana, {"test.docx"})
+        assert s_ana.type_score > s_obs.type_score
+
+    def test_dollar_amount_boosts_density(self):
+        plain = _mk("The fee is reasonable.")
+        dollar = _mk("The upfront fee is $2,500,000 due within 30 days.")
+        s_plain = score_entry(plain, {"test.docx"})
+        s_dollar = score_entry(dollar, {"test.docx"})
+        assert s_dollar.content_density > s_plain.content_density
+
+    def test_legal_ref_boosts_density(self):
+        plain = _mk("There is a provision about this.")
+        legal = _mk("Section 4.3 of the Agreement requires quarterly reporting.")
+        s_plain = score_entry(plain, {"test.docx"})
+        s_legal = score_entry(legal, {"test.docx"})
+        assert s_legal.content_density > s_plain.content_density
+
+    def test_high_value_tag_boost(self):
+        no_tag = _mk("fact without tag")
+        with_tag = _mk("fact with tag", tags=["entity_resolution", "debt_type:relation"])
+        s_no = score_entry(no_tag, {"test.docx"})
+        s_yes = score_entry(with_tag, {"test.docx"})
+        assert s_yes.tag_boost > s_no.tag_boost
+
+    def test_cross_ref_boost(self):
+        no_ref = _mk("standalone fact")
+        with_ref = _mk("supported fact", supports=["e1", "e2"])
+        s_no = score_entry(no_ref, {"test.docx"})
+        s_yes = score_entry(with_ref, {"test.docx"})
+        assert s_yes.cross_ref_score > s_no.cross_ref_score
+
+    def test_high_confidence_boosts(self):
+        low = _mk("uncertain fact", confidence=0.3)
+        high = _mk("certain fact", confidence=0.95)
+        s_low = score_entry(low, {"test.docx"})
+        s_high = score_entry(high, {"test.docx"})
+        assert s_high.composite > s_low.composite
+
+
+# -----------------------------------------------------------------------
+# Batch scoring
+# -----------------------------------------------------------------------
+
+class TestScoreAllEntries:
+    def test_empty_blackboard(self):
+        bb = Blackboard()
+        assert score_all_entries(bb) == []
+
+    def test_scores_all_active(self):
+        bb = Blackboard()
+        bb.add_entry(_mk("a"))
+        bb.add_entry(_mk("b"))
+        bb.add_entry(_mk("c"))
+        scored = score_all_entries(bb)
+        assert len(scored) == 3
+
+    def test_excludes_inactive(self):
+        bb = Blackboard()
+        bb.add_entry(_mk("active"))
+        inactive = _mk("inactive")
+        inactive.status = "disputed"
+        bb.add_entry(inactive)
+        scored = score_all_entries(bb)
+        assert len(scored) == 1
+
+    def test_diversity_penalty_for_overrepresented_doc(self):
+        bb = Blackboard()
+        # 80% from one doc
+        for i in range(8):
+            bb.add_entry(_mk(f"doc_a_{i}", doc="a.pdf"))
+        for i in range(2):
+            bb.add_entry(_mk(f"doc_b_{i}", doc="b.pdf"))
+        scored = score_all_entries(bb)
+        # Entries from doc_b should get a diversity bonus
+        b_scores = [s for s in scored if s.entry.source.document == "b.pdf"]
+        a_scores = [s for s in scored if s.entry.source.document == "a.pdf"]
+        # At least one b entry should have higher diversity bonus
+        max_b_div = max(s.source_diversity_bonus for s in b_scores)
+        max_a_div = max(s.source_diversity_bonus for s in a_scores)
+        assert max_b_div >= max_a_div
+
+
+# -----------------------------------------------------------------------
+# Compression
+# -----------------------------------------------------------------------
+
+class TestCompressForSynthesis:
+    def test_respects_target_count(self):
+        bb = Blackboard()
+        for i in range(200):
+            bb.add_entry(_mk(f"entry {i}"))
+        result = compress_for_synthesis(bb, target_count=50)
+        assert result.actual_count <= 50
+        assert len(result.selected) <= 50
+
+    def test_diversity_floor(self):
+        bb = Blackboard()
+        # 100 entries from one doc, 3 from another
+        for i in range(100):
+            bb.add_entry(_mk(f"dom_{i}", doc="dominant.pdf"))
+        for i in range(3):
+            bb.add_entry(_mk(f"minor_{i}", doc="minor.pdf"))
+        result = compress_for_synthesis(bb, target_count=20, min_per_doc=5)
+        # minor.pdf should have at least min_per_doc entries
+        minor_count = result.coverage_by_doc.get("minor.pdf", 0)
+        assert minor_count >= 3  # can't exceed what exists
+
+    def test_type_diversity(self):
+        bb = Blackboard()
+        for i in range(20):
+            bb.add_entry(_mk(f"obs_{i}", etype="observation"))
+        bb.add_entry(_mk("single analysis", etype="analysis"))
+        bb.add_entry(_mk("single calc", etype="calculation"))
+        result = compress_for_synthesis(bb, target_count=10, ensure_types=True)
+        types = set(result.coverage_by_type.keys())
+        assert "analysis" in types
+        assert "calculation" in types
+
+    def test_coverage_stats(self):
+        bb = Blackboard()
+        bb.add_entry(_mk("a", doc="doc1.pdf"))
+        bb.add_entry(_mk("b", doc="doc2.pdf"))
+        bb.add_entry(_mk("c", doc="doc1.pdf"))
+        result = compress_for_synthesis(bb, target_count=10)
+        assert "doc1.pdf" in result.coverage_by_doc
+        assert "doc2.pdf" in result.coverage_by_doc
+
+    def test_tokens_saved_estimate(self):
+        bb = Blackboard()
+        for i in range(500):
+            bb.add_entry(_mk(f"entry {i}"))
+        result = compress_for_synthesis(bb, target_count=100)
+        assert result.tokens_saved_estimate > 0
+        assert result.tokens_saved_estimate == len(result.deferred) * 75
+
+    def test_high_value_entries_selected(self):
+        bb = Blackboard()
+        # Low-value observation
+        for i in range(10):
+            bb.add_entry(_mk(f"plain fact {i}", etype="observation", confidence=0.5))
+        # High-value analysis with dollar amount
+        bb.add_entry(_mk(
+            "The termination fee is $5,000,000 per Section 4.3.",
+            etype="analysis", confidence=0.95,
+            tags=["entity_resolution"],
+        ))
+        result = compress_for_synthesis(bb, target_count=5)
+        selected_ids = {se.entry.id for se in result.selected}
+        # The high-value entry should be in the selected set
+        high_value_entry = [e for e in bb.entries if e.type == "analysis"][0]
+        assert high_value_entry.id in selected_ids
+
+
+# -----------------------------------------------------------------------
+# Ranked entries for curation
+# -----------------------------------------------------------------------
+
+class TestRankedEntriesForCuration:
+    def test_returns_entries_not_scored(self):
+        bb = Blackboard()
+        bb.add_entry(_mk("a"))
+        bb.add_entry(_mk("b"))
+        entries = ranked_entries_for_curation(bb, max_entries=10)
+        assert all(isinstance(e, Entry) for e in entries)
+
+    def test_respects_max(self):
+        bb = Blackboard()
+        for i in range(100):
+            bb.add_entry(_mk(f"entry {i}"))
+        entries = ranked_entries_for_curation(bb, max_entries=20)
+        assert len(entries) <= 20
+
+    def test_empty_blackboard(self):
+        bb = Blackboard()
+        entries = ranked_entries_for_curation(bb)
+        assert entries == []
+
+
+# -----------------------------------------------------------------------
+# Report
+# -----------------------------------------------------------------------
+
+class TestCompressionReport:
+    def test_report_structure(self):
+        bb = Blackboard()
+        bb.add_entry(_mk("a"))
+        bb.add_entry(_mk("b"))
+        result = compress_for_synthesis(bb, target_count=10)
+        report = compression_report(result)
+        assert "total_scored" in report
+        assert "selected" in report
+        assert "deferred" in report
+        assert "coverage_by_doc" in report
+        assert "coverage_by_type" in report
+        assert "top_10_scores" in report
+
+
+# -----------------------------------------------------------------------
+# Edge cases
+# -----------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_single_entry(self):
+        bb = Blackboard()
+        bb.add_entry(_mk("only entry"))
+        result = compress_for_synthesis(bb, target_count=100)
+        assert result.actual_count == 1
+
+    def test_target_larger_than_entries(self):
+        bb = Blackboard()
+        bb.add_entry(_mk("a"))
+        result = compress_for_synthesis(bb, target_count=1000)
+        assert result.actual_count == 1
+        assert len(result.deferred) == 0
+
+    def test_target_zero(self):
+        bb = Blackboard()
+        for i in range(10):
+            bb.add_entry(_mk(f"entry {i}"))
+        result = compress_for_synthesis(bb, target_count=0)
+        # min_per_doc ensures at least some entries are selected
+        assert result.actual_count >= 0

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -133,6 +133,18 @@ class TestCompressForSynthesis:
         assert result.actual_count <= 50
         assert len(result.selected) <= 50
 
+    def test_many_docs_floor_respects_cap(self):
+        # min_per_doc * num_docs (5 * 10 = 50) would exceed target_count (20);
+        # the diversity floor must NOT blow the hard cap.
+        bb = Blackboard()
+        for d in range(10):
+            for i in range(10):
+                bb.add_entry(_mk(f"d{d}_e{i}", doc=f"doc{d}.pdf"))
+        result = compress_for_synthesis(bb, target_count=20, min_per_doc=5)
+        assert result.actual_count == 20
+        # round-robin floor should still spread across many docs, not one
+        assert len(result.coverage_by_doc) >= 4
+
     def test_diversity_floor(self):
         bb = Blackboard()
         # 100 entries from one doc, 3 from another
@@ -171,7 +183,8 @@ class TestCompressForSynthesis:
             bb.add_entry(_mk(f"entry {i}"))
         result = compress_for_synthesis(bb, target_count=100)
         assert result.tokens_saved_estimate > 0
-        assert result.tokens_saved_estimate == len(result.deferred) * 75
+        expected = sum(len(se.entry.content or "") for se in result.deferred) // 4
+        assert result.tokens_saved_estimate == expected
 
     def test_high_value_entries_selected(self):
         bb = Blackboard()
@@ -258,5 +271,6 @@ class TestEdgeCases:
         for i in range(10):
             bb.add_entry(_mk(f"entry {i}"))
         result = compress_for_synthesis(bb, target_count=0)
-        # min_per_doc ensures at least some entries are selected
-        assert result.actual_count >= 0
+        # target_count is a hard cap; zero means select nothing.
+        assert result.actual_count == 0
+        assert len(result.deferred) == 10


### PR DESCRIPTION
## Blackboard compression for synthesis (Research Q3)

Addresses the open research question: *"What's the best strategy for selecting, ranking, or clustering entries to maximize information density in the synthesis prompt without losing critical details?"*

Adds a **deterministic, zero-token pre-ranking and diversity-aware selection** step that can bound the entry set handed to a context-limited LLM step.

### What it adds (`src/swarm/compression.py`)
- `score_entry` / `score_all_entries` — composite relevance score per active entry from entry type, content density (dollar amounts, percentages, legal refs, dates, obligations), high-value tags, cross-reference degree, source diversity, and confidence. Source diversity is assigned in batch scoring, where per-document counts are available (under-represented docs get a bonus, dominant docs a penalty).
- `compress_for_synthesis(...)` — selects the highest-value entries under a **hard `target_count` cap**, in three phases: a round-robin per-document diversity floor, a type-diversity pass (≥ 1 entry per type), then score-fill. `len(selected) ≤ target_count` always holds, including when `min_per_doc × num_docs` would exceed the cap.
- `ranked_entries_for_curation(...)` / `compression_report(...)` — convenience accessor + diagnostics.

### Design notes
- Deterministic, **zero LLM calls**. Stable ordering (composite descending, ties by entry order).
- **Relationship to `curation.py`:** curation deliberately enumerates *every* fact per document. This module is **not** a replacement for that — pre-filtering would defeat curation's recall goal. It is a **context-budget guard** for the case where the active set exceeds a hard context budget and some bounded loss is unavoidable; otherwise pass the full set to curation. This is documented on `ranked_entries_for_curation`. Opt-in; no existing call sites are changed.

### Tests
`tests/test_compression.py` — 24 tests covering scoring components, batch diversity adjustment, the hard cap (including a many-document case where the floor would otherwise overflow), type/doc coverage, the token estimate, ranking, and edge cases. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
