### PR TITLE
fix: correct synthesis token accounting across thread boundary

### DIFF
--- a/src/swarm/synthesis.py
+++ b/src/swarm/synthesis.py
@@ -20,7 +20,7 @@ from .worker_dispatch import (
     call_model,
     end_call_model_usage,
     get_last_call_usage,
-    merge_call_usage,
+    set_last_call_usage,
 )
 
 
@@ -59,6 +59,19 @@ def render_entry(e: Entry, max_content: int = 400) -> str:
     return "".join(parts)
 
 
+def _finalize_synthesis_usage(usage_by_model: dict) -> None:
+    """Combine usage collected from parallel section drafts with whatever the
+    aggregate accumulated from sequential calls, then install it as the last
+    call's usage so blackboard.add_tokens_from_last_call picks up everything.
+    """
+    end_call_model_usage()
+    aggregate_usage, _, _, _ = get_last_call_usage()
+    combined: dict = {}
+    _merge_usage(combined, aggregate_usage)
+    _merge_usage(combined, usage_by_model)
+    set_last_call_usage(combined)
+
+
 def synthesize_deliverable(blackboard: Blackboard, must_include: list[dict],
                            caller: ModelCaller) -> tuple[str, int]:
     begin_call_model_usage()
@@ -69,12 +82,16 @@ def synthesize_deliverable(blackboard: Blackboard, must_include: list[dict],
 
         # If many items, use sectioned synthesis to avoid output truncation
         if used_sectioned:
-            draft, draft_tokens = _sectioned_synthesis(blackboard, must_include, active, caller)
+            draft, draft_tokens, usage_by_model = _sectioned_synthesis(
+                blackboard, must_include, active, caller,
+            )
         else:
             draft, draft_tokens = _draft_synthesis(blackboard, must_include, active, caller)
+            usage_by_model = {}
         total_tokens += draft_tokens
 
         if not must_include:
+            _finalize_synthesis_usage(usage_by_model)
             return draft, total_tokens
 
         # Phase 2: Verify — which must_include items are missing from the draft?
@@ -82,6 +99,7 @@ def synthesize_deliverable(blackboard: Blackboard, must_include: list[dict],
         total_tokens += verify_tokens
 
         if not missing:
+            _finalize_synthesis_usage(usage_by_model)
             return draft, total_tokens
 
         # Phase 3: Augment — targeted repair for missing items
@@ -101,6 +119,7 @@ def synthesize_deliverable(blackboard: Blackboard, must_include: list[dict],
         total_tokens += ph_tokens
         augmented = repaired_map.get("deliverable", augmented)
 
+        _finalize_synthesis_usage(usage_by_model)
         return augmented, total_tokens
     finally:
         end_call_model_usage()
@@ -149,7 +168,9 @@ def synthesize_file_deliverables(
 
         outputs: dict[str, str] = {}
         total_tokens = 0
+        usage_by_model: dict = {}
         if not filenames:
+            _finalize_synthesis_usage(usage_by_model)
             return outputs, total_tokens
 
         item_pool = _numbered_must_include_pool(must_include)
@@ -231,7 +252,9 @@ def synthesize_file_deliverables(
                 selected_items, plan["file_requirements"], filename,
             )
 
-            draft, draft_tokens = _draft_file_deliverable(
+            # _draft_file_deliverable's usage dict is already reflected in the
+            # call_model aggregate (same thread, sequential) — don't double-count it.
+            draft, draft_tokens, _ = _draft_file_deliverable(
                 blackboard, filename, plan["file_requirements"], selected_items,
                 plan.get("contract", _default_artifact_contract(filename)),
                 caller,
@@ -264,6 +287,7 @@ def synthesize_file_deliverables(
         outputs, ph_tokens = _repair_placeholders(outputs, blackboard, caller)
         total_tokens += ph_tokens
 
+        _finalize_synthesis_usage(usage_by_model)
         return outputs, total_tokens
     finally:
         end_call_model_usage()
@@ -341,7 +365,7 @@ def _cap_sections(
 
 
 def _sectioned_synthesis(blackboard: Blackboard, must_include: list[dict],
-                         active: list[Entry], caller: ModelCaller) -> tuple[str, int]:
+                         active: list[Entry], caller: ModelCaller) -> tuple[str, int, dict]:
     """Draft deliverable in sections to avoid output truncation on large tasks."""
     total_tokens = 0
 
@@ -381,7 +405,7 @@ def _sectioned_synthesis(blackboard: Blackboard, must_include: list[dict],
             jobs.append((len(jobs), chunk_name, prompt))
 
     if not jobs:
-        return "", total_tokens
+        return "", total_tokens, {}
 
     max_workers = min(
         len(jobs),
@@ -423,7 +447,6 @@ def _sectioned_synthesis(blackboard: Blackboard, must_include: list[dict],
                     blackboard, completed, len(jobs), chunk_name,
                 )
 
-    merge_call_usage(usage_by_model)
     section_drafts = []
     for result in results:
         if result is None:
@@ -436,7 +459,7 @@ def _sectioned_synthesis(blackboard: Blackboard, must_include: list[dict],
     # Assemble deterministically. Do not ask the model to reproduce completed
     # sections; that can drop exactly the details sectioning is meant to save.
     assembled = _clean_assembled_deliverable("\n\n".join(section_drafts))
-    return assembled, total_tokens
+    return assembled, total_tokens, usage_by_model
 
 
 def _section_prompt(
@@ -1262,7 +1285,7 @@ def _draft_file_deliverable(
     selected_items: list[dict],
     artifact_contract: dict,
     caller: ModelCaller,
-) -> tuple[str, int]:
+) -> tuple[str, int, dict]:
     if len(selected_items) > SECTION_THRESHOLD:
         return _sectioned_file_deliverable(
             blackboard, filename, file_reqs, selected_items,
@@ -1307,10 +1330,11 @@ CRITICAL INSTRUCTIONS:
 6. For redlines or markups, provide actual revised language and targeted drafting notes."""
 
     payload, tokens = call_model(caller, prompt, max_tokens=16384, json_mode=False)
+    by_model, _, _, _ = get_last_call_usage()
     text = payload.get("text", "").strip()
     if not text:
         text = str(payload)
-    return _clean_assembled_deliverable(text), tokens
+    return _clean_assembled_deliverable(text), tokens, (by_model or {})
 
 
 def _sectioned_file_deliverable(
@@ -1320,8 +1344,9 @@ def _sectioned_file_deliverable(
     selected_items: list[dict],
     artifact_contract: dict,
     caller: ModelCaller,
-) -> tuple[str, int]:
+) -> tuple[str, int, dict]:
     total_tokens = 0
+    usage_by_model: dict = {}
 
     by_section: dict[str, list[dict]] = {}
     for item in selected_items:
@@ -1395,6 +1420,8 @@ CRITICAL INSTRUCTIONS:
                 caller, prompt, max_tokens=SECTION_DRAFT_MAX_TOKENS, json_mode=False,
             )
             total_tokens += tokens
+            by_model, _, _, _ = get_last_call_usage()
+            _merge_usage(usage_by_model, by_model)
             text = payload.get("text", "").strip()
             if not text:
                 continue
@@ -1406,7 +1433,11 @@ CRITICAL INSTRUCTIONS:
                 f"completed {filename}: {chunk_name}",
             )
 
-    return _clean_assembled_deliverable("\n\n".join(section_drafts)), total_tokens
+    return (
+        _clean_assembled_deliverable("\n\n".join(section_drafts)),
+        total_tokens,
+        usage_by_model,
+    )
 
 
 def _section_heading_for_file(filename: str, section_name: str) -> str:

--- a/src/swarm/worker_dispatch.py
+++ b/src/swarm/worker_dispatch.py
@@ -116,22 +116,6 @@ def set_last_call_usage(by_model: dict | None) -> None:
     _usage_state.last_out = sum(v.get("output", 0) for v in by_model.values())
 
 
-def merge_call_usage(by_model: dict | None) -> None:
-    """Merge externally collected usage into the active aggregate, if any."""
-    if not isinstance(by_model, dict):
-        return
-    aggregate = getattr(_usage_state, "usage_aggregate", None)
-    if aggregate is None:
-        return
-    for model, usage in by_model.items():
-        if model not in aggregate:
-            aggregate[model] = {"input": 0, "output": 0, "total": 0, "calls": 0}
-        aggregate[model]["input"] += usage.get("input", 0)
-        aggregate[model]["output"] += usage.get("output", 0)
-        aggregate[model]["total"] += usage.get("total", 0)
-        aggregate[model]["calls"] += usage.get("calls", 0)
-
-
 def _record_aggregate_usage(result) -> None:
     aggregate = getattr(_usage_state, "usage_aggregate", None)
     if aggregate is None:

--- a/tests/test_sectioned_synthesis.py
+++ b/tests/test_sectioned_synthesis.py
@@ -56,7 +56,7 @@ def test_sectioned_synthesis_preserves_section_drafts_without_final_rewrite():
         "Beta section SENTINEL_BETA",
     ])
 
-    draft, tokens = _sectioned_synthesis(blackboard, must_include, active, caller)
+    draft, tokens, _ = _sectioned_synthesis(blackboard, must_include, active, caller)
 
     assert tokens == 30
     assert len(caller.prompts) == 2
@@ -72,7 +72,7 @@ def test_sectioned_synthesis_strips_redundant_model_section_headings():
         "Required Findings\n\nRequired Findings\n\nThe finding survives.",
     ])
 
-    draft, _ = _sectioned_synthesis(blackboard, must_include, [], caller)
+    draft, _, _ = _sectioned_synthesis(blackboard, must_include, [], caller)
 
     assert draft == "## Required Findings\n\nThe finding survives."
 
@@ -111,7 +111,7 @@ def test_sectioned_synthesis_chunks_large_single_section_and_scopes_evidence():
         "RISK_CHUNK_4",
     ])
 
-    draft, tokens = _sectioned_synthesis(blackboard, must_include, active, caller)
+    draft, tokens, _ = _sectioned_synthesis(blackboard, must_include, active, caller)
 
     assert tokens == 60
     assert "## Risk Part 1\n\nRISK_CHUNK_1" in draft

--- a/tests/test_synthesis_token_accounting.py
+++ b/tests/test_synthesis_token_accounting.py
@@ -1,0 +1,94 @@
+from src.swarm.blackboard import Blackboard
+from src.swarm.models import ModelResult
+from src.swarm.synthesis import _merge_usage, _sectioned_synthesis, synthesize_deliverable
+
+
+class FakeCaller:
+    def __init__(self, responses: list[str], model: str = "fake-model"):
+        self.responses = list(responses)
+        self.model = model
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str, *, max_tokens: int = 8192,
+                 temperature: float = 0.05, json_mode: bool = True) -> ModelResult:
+        self.prompts.append(prompt)
+        text = self.responses.pop(0) if self.responses else ""
+        return ModelResult(
+            text=text,
+            tokens_input=10,
+            tokens_output=5,
+            tokens_total=15,
+            model=self.model,
+            latency_ms=1,
+        )
+
+
+def _large_must_include(n: int = 51) -> list[dict]:
+    return [{"section": "Risk", "summary": f"Explain risk {i}."} for i in range(n)]
+
+
+def test_sectioned_synthesis_returns_nonempty_usage_dict_matching_tokens():
+    blackboard = Blackboard(task_instruction="Prepare a large memo.")
+    must_include = _large_must_include()
+    caller = FakeCaller(["RISK_CHUNK_1", "RISK_CHUNK_2", "RISK_CHUNK_3"])
+
+    draft, tokens, usage_by_model = _sectioned_synthesis(
+        blackboard, must_include, [], caller,
+    )
+
+    assert usage_by_model
+    assert tokens == 45
+    assert sum(v["total"] for v in usage_by_model.values()) == tokens
+
+
+def test_synthesize_deliverable_populates_blackboard_cost_by_model():
+    blackboard = Blackboard(task_instruction="Prepare a large memo.")
+    must_include = _large_must_include()
+    caller = FakeCaller([
+        "RISK_CHUNK_1", "RISK_CHUNK_2", "RISK_CHUNK_3",
+        '{"missing":[]}',
+    ])
+
+    draft, tokens = synthesize_deliverable(blackboard, must_include, caller)
+    blackboard.add_tokens_from_last_call(tokens)
+
+    assert blackboard.cost_by_model
+    assert blackboard.cost_by_model["fake-model"]["total"] == tokens
+
+
+def test_parallel_section_drafts_token_counts_summed_across_calls():
+    blackboard = Blackboard(task_instruction="Prepare a large memo.")
+    must_include = _large_must_include()
+    # Force a verify+augment cycle on top of the parallel section drafts so
+    # multiple model calls happen both on worker threads and the coordinator.
+    caller = FakeCaller([
+        "RISK_CHUNK_1", "RISK_CHUNK_2", "RISK_CHUNK_3",
+        '{"missing":[{"item_number":1,"summary":"Explain risk 0.","entry_id":""}]}',
+        "AUGMENTED_RISK_CHUNK",
+    ])
+
+    draft, tokens = synthesize_deliverable(blackboard, must_include, caller)
+    blackboard.add_tokens_from_last_call(tokens)
+
+    assert tokens == 75
+    assert blackboard.total_tokens_used == 75
+    assert blackboard.cost_by_model["fake-model"]["total"] == 75
+    assert blackboard.cost_by_model["fake-model"]["calls"] == 5
+
+
+def test_merge_usage_accumulates_across_multiple_calls():
+    target: dict = {}
+    _merge_usage(target, {"m1": {"input": 10, "output": 5, "total": 15, "calls": 1}})
+    _merge_usage(target, {"m1": {"input": 20, "output": 10, "total": 30, "calls": 1}})
+    _merge_usage(target, {"m2": {"input": 1, "output": 1, "total": 2, "calls": 1}})
+
+    assert target["m1"] == {"input": 30, "output": 15, "total": 45, "calls": 2}
+    assert target["m2"] == {"input": 1, "output": 1, "total": 2, "calls": 1}
+
+
+def test_merge_usage_ignores_non_dict_source():
+    target: dict = {"m1": {"input": 1, "output": 1, "total": 2, "calls": 1}}
+    _merge_usage(target, None)
+    _merge_usage(target, "not a dict")
+
+    assert target == {"m1": {"input": 1, "output": 1, "total": 2, "calls": 1}}


### PR DESCRIPTION
## What was broken

`end_call_model_usage()` unconditionally overwrites `last_by_model` with the coordinator thread's own aggregate. When `_sectioned_synthesis` ran parallel section drafts via `ThreadPoolExecutor` and then `synthesize_deliverable` made any sequential call afterward (verify completeness, augment missing items — the common path for large documents), the section-draft token totals were silently overwritten and dropped from `blackboard.cost_by_model`.

The original hypothesis was a cross-thread `merge_call_usage` failure. The actual loss point was the overwrite in `end_call_model_usage()` — a more precise diagnosis confirmed by a direct test (5 calls across both phases, all 75 tokens accounted for after the fix).

A naive re-merge of usage also caused double-counting (`tokens_input == 110` instead of `60`) for the sequential file-deliverable path, caught and fixed before merging.

## The fix

- `_sectioned_synthesis` now returns `tuple[str, int, dict]` (draft, tokens, usage_by_model) instead of merging into thread-local state internally
- `_finalize_synthesis_usage(usage_by_model)` flushes the coordinator-thread aggregate, combines it with parallel section usage, and installs the result via `set_last_call_usage` before `end_call_model_usage()` runs
- `synthesize_deliverable` calls this helper before each return point
- `_draft_file_deliverable` / `_sectioned_file_deliverable` standardized to the same 3-tuple shape for consistency; `synthesize_file_deliverables` deliberately discards the returned usage dict since those calls are sequential and already captured by the existing aggregate
- Removed `merge_call_usage` — no remaining callers after the refactor

## Files changed

- `src/swarm/synthesis.py`
- `src/swarm/worker_dispatch.py`
- `tests/test_synthesis_token_accounting.py` (5 new tests)
- `tests/test_sectioned_synthesis.py` (updated 3 call sites for new tuple signature)

All 355 tests pass (350 pre-existing + 5 new), 3 skipped, no regressions.