### PR TITLE
Fix S-03: move pytest to a dev dependency extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,15 @@ dependencies = [
     "trafilatura>=2.0.0",
     # Utilities
     "pandas>=2.0.0",
-    # Testing
-    "pytest>=8.0.0",
     # MCP server
     "mcp>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov",
+    "pytest-asyncio",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Hi team! 👋

I am working through the Tier 1 Good First Issues for the bounty program. Since the Issues tab is disabled, I am submitting this PR directly to claim Item S-03.

Description: Moved pytest out of the standard runtime [project.dependencies] in pyproject.toml and into a new [project.optional-dependencies] dev section.

Verification: Verified pip install -e ".[dev]" successfully installs pytest, while standard pip install -e . does not.