### PR TITLE
Fix S-02: extract duplicated MODEL_PRICING into src/constants.py

### DIFF
--- a/src/bench.py
+++ b/src/bench.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .constants import DEFAULT_PRICING, MODEL_PRICING
+
 
 # ---------------------------------------------------------------------------
 # Benchmark tier definitions
@@ -207,18 +209,6 @@ class IrysSwarmBackend:
 
 
 def _estimate_cost(blackboard) -> float:
-    MODEL_PRICING = {
-        "gemini-3.1-flash-lite": {"input": 0.25, "output": 1.50},
-        "gemini-3-flash-preview": {"input": 0.50, "output": 3.00},
-        "gemini-3.5-flash": {"input": 1.50, "output": 9.00},
-        "gemini-3.1-pro-preview": {"input": 2.00, "output": 12.00},
-        "claude-fable-5": {"input": 10.00, "output": 50.00},
-        "claude-opus-4-8": {"input": 5.00, "output": 25.00},
-        "claude-opus-4-7": {"input": 5.00, "output": 25.00},
-        "claude-opus-4-6": {"input": 5.00, "output": 25.00},
-        "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
-    }
-    DEFAULT_PRICING = {"input": 0.25, "output": 1.50}
     cost = 0.0
     for model, usage in blackboard.cost_by_model.items():
         pricing = MODEL_PRICING.get(model, DEFAULT_PRICING)

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,19 @@
+"""Shared constants for the irys-stateful-swarms package."""
+from __future__ import annotations
+
+# Cost per 1M tokens (USD) — used in runner.py and bench.py
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    "gemini-3.1-flash-lite": {"input": 0.25, "output": 1.50},
+    "gemini-3-flash-preview": {"input": 0.50, "output": 3.00},
+    "gemini-3.5-flash": {"input": 1.50, "output": 9.00},
+    "gemini-3.1-pro-preview": {"input": 2.00, "output": 12.00},
+    "claude-fable-5": {"input": 10.00, "output": 50.00},
+    "claude-opus-4-8": {"input": 5.00, "output": 25.00},
+    "claude-opus-4-7": {"input": 5.00, "output": 25.00},
+    "claude-opus-4-6": {"input": 5.00, "output": 25.00},
+    "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+    "gpt-5.5": {"input": 2.00, "output": 12.00},
+    "gpt-5.4": {"input": 1.50, "output": 8.00},
+}
+
+DEFAULT_PRICING: dict[str, float] = {"input": 0.25, "output": 1.50}

--- a/src/runner.py
+++ b/src/runner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from docx import Document as DocxDocument
 from docx.shared import Pt
 
+from .constants import DEFAULT_PRICING, MODEL_PRICING
 from .ingestion import discover_documents
 from .providers.gemini import GeminiCaller
 from .swarm import run_swarm
@@ -141,20 +142,6 @@ def run_single_task(task_dir: Path, output_dir: Path, *,
     tokens_out = blackboard.tokens_output
 
     # Cost calculation per model
-    MODEL_PRICING = {
-        "gemini-3.1-flash-lite": {"input": 0.25, "output": 1.50},
-        "gemini-3-flash-preview": {"input": 0.50, "output": 3.00},
-        "gemini-3.5-flash": {"input": 1.50, "output": 9.00},
-        "gemini-3.1-pro-preview": {"input": 2.00, "output": 12.00},
-        "claude-fable-5": {"input": 10.00, "output": 50.00},
-        "claude-opus-4-8": {"input": 5.00, "output": 25.00},
-        "claude-opus-4-7": {"input": 5.00, "output": 25.00},
-        "claude-opus-4-6": {"input": 5.00, "output": 25.00},
-        "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
-        "gpt-5.5": {"input": 2.00, "output": 12.00},
-        "gpt-5.4": {"input": 1.50, "output": 8.00},
-    }
-    DEFAULT_PRICING = {"input": 0.25, "output": 1.50}
 
     cost_total = 0.0
     cost_breakdown = {}


### PR DESCRIPTION
Hi team! 👋

I am working through the Tier 1 Good First Issues for the bounty program. Since the Issues tab is disabled, I am submitting this PR directly to claim Item S-02.

Description: Extracted the duplicated MODEL_PRICING dictionary from both runner.py and bench.py into a shared src/constants.py file to maintain a single source of truth for model prices.

Verification: Verified all imports resolve correctly and model pricing keys match the union of both previous dictionaries (11 models total).