### PR TITLE
Fix S-01: extract duplicated _env_on() into swarm/utils.py

### DIFF
--- a/src/swarm/artifact_commitments.py
+++ b/src/swarm/artifact_commitments.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .blackboard import Blackboard
 from .models import Entry
+from .utils import _env_on
 from .verification import extract_verification_targets
 
 
@@ -528,7 +529,3 @@ def _counts(values) -> dict:
         key = str(value or "unknown")
         counts[key] = counts.get(key, 0) + 1
     return counts
-
-
-def _env_on(name: str) -> bool:
-    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}

--- a/src/swarm/blackboard_maintenance.py
+++ b/src/swarm/blackboard_maintenance.py
@@ -8,6 +8,7 @@ from typing import Any
 from .blackboard import Blackboard
 from .models import Entry, EntrySource, ModelCaller, WorkerRecord, gen_entry_id
 from .prompt_audit import PromptAuditContext
+from .utils import _env_on
 from .worker_dispatch import begin_call_model_usage, call_model, end_call_model_usage
 
 
@@ -597,7 +598,3 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
-
-
-def _env_on(name: str) -> bool:
-    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}

--- a/src/swarm/debt_sensors.py
+++ b/src/swarm/debt_sensors.py
@@ -9,6 +9,7 @@ from .blackboard import Blackboard
 from .models import Entry, EntrySource, ModelCaller, WorkerRecord, gen_entry_id
 from .prompt_audit import PromptAuditContext
 from .section_index import resolve_section_text
+from .utils import _env_on
 from .worker_dispatch import begin_call_model_usage, call_model, end_call_model_usage
 
 
@@ -1472,7 +1473,3 @@ def _safe_float(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError):
         return 0.0
-
-
-def _env_on(name: str) -> bool:
-    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}

--- a/src/swarm/derived_work.py
+++ b/src/swarm/derived_work.py
@@ -11,6 +11,7 @@ from .models import (
     Entry, EntrySource, ModelCaller, WorkerRecord, gen_entry_id,
 )
 from .prompt_audit import PromptAuditContext
+from .utils import _env_on
 from .verification import normalize_dollar, verify_calculation_expression
 from .worker_dispatch import begin_call_model_usage, call_model, end_call_model_usage
 
@@ -490,10 +491,6 @@ def _safe_float(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError):
         return 0.0
-
-
-def _env_on(name: str) -> bool:
-    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _numeric_input_count(required_inputs: list[Any]) -> int:

--- a/src/swarm/source_claims.py
+++ b/src/swarm/source_claims.py
@@ -11,6 +11,7 @@ from .models import Entry, ModelCaller
 from .prompt_audit import PromptAuditContext
 from .source_custody import source_document_is_valid
 from .synthesis import render_entry
+from .utils import _env_on
 from .worker_dispatch import begin_call_model_usage, call_model, end_call_model_usage
 
 
@@ -536,7 +537,3 @@ def _as_str_list(raw: Any) -> list[str]:
     if isinstance(raw, str) and raw.strip():
         return [part.strip() for part in raw.split(",") if part.strip()]
     return []
-
-
-def _env_on(name: str) -> bool:
-    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}

--- a/src/swarm/utils.py
+++ b/src/swarm/utils.py
@@ -1,0 +1,9 @@
+"""Shared utilities for the swarm package."""
+from __future__ import annotations
+
+import os
+
+
+def _env_on(name: str) -> bool:
+    """Return True if the named environment variable is set to a truthy value."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}


### PR DESCRIPTION
Hi team! 👋

I am working through the Tier 1 Good First Issues for the bounty program. Since the Issues tab is disabled, I am submitting this PR directly to claim Item S-01.

Description: Extracted the duplicated _env_on() function, which was defined 5 separate times across different swarm modules, into a single shared utility function at src/swarm/utils.py.

Verification: Verified all imports resolve correctly and tests pass.
