### PR TITLE
Fix S-06: add __repr__ to RotatingCaller

### DIFF
--- a/src/providers/rotating.py
+++ b/src/providers/rotating.py
@@ -28,3 +28,11 @@ class RotatingCaller:
             prompt, max_tokens=max_tokens, temperature=temperature,
             json_mode=json_mode,
         )
+
+    def __repr__(self) -> str:
+        return (
+            f"RotatingCaller("
+            f"callers={len(self._callers)}, "
+            f"pattern={self._pattern}, "
+            f"idx={self._idx})"
+        )


### PR DESCRIPTION
Hi team! 👋

I am working through the Tier 1 Good First Issues for the bounty program. Since the Issues tab is disabled, I am submitting this PR directly to claim Item S-06.

Description: Added a descriptive __repr__ method to RotatingCaller in src/providers/rotating.py that includes the caller count, pattern, and current index for easier debugging.

Verification: Tested the output of repr() on a RotatingCaller instance.