### PR TITLE
Fix S-09: add node_modules/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ codex_*.md
 .env
 .env.local
 .env.anthropic
+
+# Node
+node_modules/


### PR DESCRIPTION
Hi team! 👋

I am working through the Tier 1 Good First Issues for the bounty program. Since the Issues tab is disabled, I am submitting this PR directly to claim Item S-09.

Description: Added node_modules/ to the root .gitignore file to prevent accidental commits of local dependencies.

Verification: Confirmed node_modules/ is listed in the ignored directories list.