### PR TITLE
Fix S-04: remove duplicate bench_root key in phase0_smoke_48.json

### DIFF
--- a/benchmarks/manifests/phase0_smoke_48.json
+++ b/benchmarks/manifests/phase0_smoke_48.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "bench_root":  "$HARVEY_BENCH_ROOT",
     "tasks":  [
                   {
@@ -145,6 +145,5 @@
                   {
                       "task_id":  "white-collar-defense-investigations/identify-suspicious-patterns-in-financial-transaction-records"
                   }
-              ],
-    "bench_root":  "C:/Users/devan/OneDrive/Desktop/Projects/harvey-labs"
+              ]
 }


### PR DESCRIPTION
Hi team! 👋

I am working through the Tier 1 Good First Issues for the bounty program. Since the Issues tab is disabled, I am submitting this PR directly to claim Item S-04.

Description: Removed the duplicate hardcoded bench_root key from the JSON manifest so it correctly falls back to using the $HARVEY_BENCH_ROOT environment variable.

Verification: Verified the JSON parses correctly and only contains one bench_root key.