### PR TITLE
feat: add stateful duplicate entity name resolution

### DIFF
--- a/.superpowers/sdd/2026-08-14-minimal-regression-recovery/task-3-report.md
+++ b/.superpowers/sdd/2026-08-14-minimal-regression-recovery/task-3-report.md
@@ -1,0 +1,49 @@
+# Task 3 report: decision-only final synthesis injection
+
+## Scope delivered
+
+- Moved final entity maintenance to immediately after `consolidate_items(...)`, so curation completes before confirmed decisions are projected.
+- Removed the predecessor generic entity-maintenance packet path. Active `duplicate_name_resolution` cards that are not already represented in `must_include` are appended one at a time.
+- Each injected item preserves the card's JSON `content` as its summary and has `section="Entity resolution"`, `importance="critical"`, and `source="entity_maintenance"`.
+- No `entity_information` cards, JSON parsing, profile injection, new helper, or resolver changes were added.
+
+## TDD evidence
+
+1. Replaced the predecessor generic-card test with `test_final_duplicate_decisions_are_explicit_synthesis_items_after_curation`.
+2. Red run before the production change:
+
+   ```text
+   AssertionError: assert 2 < 1
+   events: ['periodic', 'final', 'curate']
+   ```
+
+   This demonstrated the old final-maintenance-before-curation order.
+3. Green run after the production change:
+
+   ```text
+   1 passed, 5 deselected in 0.07s
+   ```
+
+## Verification
+
+```text
+/home/gvw/Desktop/AI_coding/legal_AI/iryst_stateful_swarm_duplicate_name_resolution_venv/bin/python -m pytest -q tests/test_entity_maintenance.py tests/test_entity_candidate_scoring.py tests/test_entity_profiles.py
+19 passed in 0.11s
+```
+
+Deferred removal scan:
+
+```text
+rg -n --glob '*.py' 'entity_information|project_entity_information_cards' .
+exit code 1; no matches
+
+rg -n 'entity_information|project_entity_information_cards' src
+exit code 1; no matches
+```
+
+An unfiltered text scan of the full checkout still finds expected historical references in planning documents and recorded `judge_comparisons` artifacts; no live Python or `src` references remain.
+
+## Scope and worktree hygiene
+
+- Only `src/swarm/__init__.py`, `tests/test_entity_maintenance.py`, and this report are Task 3 changes.
+- Existing unrelated modifications remain unstaged and untouched.

--- a/README.md
+++ b/README.md
@@ -350,6 +350,21 @@ This is what makes stateful swarms fundamentally different from stateless approa
 
 Browse any task's `swarm/blackboard_iter_*.json` files to trace the full reasoning evolution. The complete outputs for all 1,251 tasks are available in the [GitHub Releases](../../releases).
 
+### Structured entity annotations and duplicate resolution
+
+Entity maintenance keeps entity context grounded in the document record. It includes active `direct-document-worker` cards: findings produced by workers with direct document context. It excludes derived cards — including analysis, synthesis, `entity_information`, and prior resolution cards — from creating or repairing entity profiles.
+
+Configure the maintenance cycle in task metadata. The defaults are:
+
+- `entity_resolution_interval_iterations=3`: run after every third worker iteration.
+- `duplicate_review_threshold=0.85`: send sufficiently supported duplicate candidates for review.
+- `entity_profile_min_card_count=2`: require this many source cards before creating a new profile.
+- `entity_repair_max_mentions_per_card=20`: cap deterministic literal mention repair on each card.
+
+The swarm also performs a final maintenance run immediately before synthesis. `entity_information` cards provide concise, current entity context on the blackboard. Candidate evidence, as well as uncertain or rejected outcomes, remains in `swarm/entity_resolution/state.json` for auditability rather than being promoted to the blackboard.
+
+Only confirmed `same_entity` and `same_name_distinct_entity` results appear as `duplicate_name_resolution` cards. Deterministic repair improves entity-mention recall, but it cannot guarantee complete entity mentions in every document card.
+
 ## Why stateful swarms matter
 
 The AI industry has a statefulness problem. Every major AI system today — coding agents, research assistants, document analysts — treats each interaction as an isolated event. The model reasons, produces output, and forgets. The next interaction starts from zero. Context windows get compacted, destroying details that seemed unimportant but become critical later. Session boundaries erase everything.

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Browse any task's `swarm/blackboard_iter_*.json` files to trace the full reasoni
 
 ### Structured entity annotations and duplicate resolution
 
-Entity maintenance keeps entity context grounded in the document record. It includes active `direct-document-worker` cards: findings produced by workers with direct document context. It excludes derived cards — including analysis, synthesis, `entity_information`, and prior resolution cards — from creating or repairing entity profiles.
+Entity maintenance keeps entity context grounded in the document record. It includes active `direct-document-worker` cards: findings produced by workers with direct document context. It excludes derived cards — including analysis, synthesis, and prior resolution cards — from creating or repairing persistent entity profiles.
 
 Configure the maintenance cycle in task metadata. The defaults are:
 
@@ -361,7 +361,7 @@ Configure the maintenance cycle in task metadata. The defaults are:
 - `entity_profile_min_card_count=2`: require this many source cards before creating a new profile.
 - `entity_repair_max_mentions_per_card=20`: cap deterministic literal mention repair on each card.
 
-The swarm also performs a final maintenance run immediately before synthesis. `entity_information` cards provide concise, current entity context on the blackboard. Candidate evidence, as well as uncertain or rejected outcomes, remains in `swarm/entity_resolution/state.json` for auditability rather than being promoted to the blackboard.
+The swarm also performs a final maintenance run before synthesis. Persistent source-linked profiles, candidate evidence, and uncertain or rejected outcomes remain in `swarm/entity_resolution/state.json` for auditability rather than being promoted to the blackboard.
 
 Only confirmed `same_entity` and `same_name_distinct_entity` results appear as `duplicate_name_resolution` cards. Deterministic repair improves entity-mention recall, but it cannot guarantee complete entity mentions in every document card.
 

--- a/src/entity_resolution/__init__.py
+++ b/src/entity_resolution/__init__.py
@@ -1,0 +1,60 @@
+"""Public API for deterministic company and person duplicate resolution."""
+
+from .io import load_records_json, write_result_json
+from .models import (
+    CompanyCandidate,
+    CompanyCluster,
+    CompanyNameForms,
+    CompanyRecord,
+    DuplicateNameReport,
+    ResolutionResult,
+    ResolverConfig,
+)
+from .normalization import normalize_company_name
+from .resolver import resolve_companies
+from .review import generate_review_prompt
+from .person_io import load_person_records_json, write_person_result_json
+from .person_models import (
+    PersonAttribute,
+    PersonAutoMatch,
+    PersonEvidence,
+    PersonNameForms,
+    PersonProfile,
+    PersonRecord,
+    PersonResolutionResult,
+    UncertainConnection,
+)
+from .person_normalization import normalize_person_name
+from .person_resolver import resolve_people
+from .person_review import generate_person_review_prompt
+from .token_stats import token_weights, weighted_token_overlap
+
+__all__ = [
+    "CompanyCandidate",
+    "CompanyCluster",
+    "CompanyNameForms",
+    "CompanyRecord",
+    "DuplicateNameReport",
+    "PersonAttribute",
+    "PersonAutoMatch",
+    "PersonEvidence",
+    "PersonNameForms",
+    "PersonProfile",
+    "PersonRecord",
+    "PersonResolutionResult",
+    "ResolutionResult",
+    "ResolverConfig",
+    "UncertainConnection",
+    "generate_person_review_prompt",
+    "generate_review_prompt",
+    "load_person_records_json",
+    "load_records_json",
+    "normalize_company_name",
+    "normalize_person_name",
+    "resolve_companies",
+    "resolve_people",
+    "token_weights",
+    "weighted_token_overlap",
+    "write_person_result_json",
+    "write_result_json",
+]

--- a/src/entity_resolution/io.py
+++ b/src/entity_resolution/io.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""JSON boundary functions for validated records and stable results."""
+
+import json
+from typing import Any
+
+from .models import CompanyRecord, ResolutionResult
+from .normalization import normalize_company_name
+
+
+def load_records_json(payload: str) -> list[CompanyRecord]:
+    data = json.loads(payload)
+    if not isinstance(data, list):
+        raise ValueError("input must be a JSON array")
+    records: list[CompanyRecord] = []
+    seen_record_ids: set[str] = set()
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ValueError(f"record at index {index} must be an object")
+        record_id = str(item.get("record_id", "")).strip()
+        if not record_id:
+            raise ValueError(f"record at index {index} is missing required field record_id")
+        if record_id in seen_record_ids:
+            raise ValueError(f"duplicate record_id: {record_id}")
+        seen_record_ids.add(record_id)
+        name = str(item.get("name", "")).strip()
+        if not name or not normalize_company_name(name).core:
+            raise ValueError(f"record at index {index} is missing required field name")
+        metadata = item.get("metadata", {})
+        if metadata is None:
+            metadata = {}
+        if not isinstance(metadata, dict):
+            raise ValueError(f"record {item['record_id']} metadata must be an object")
+        snippets = item.get("snippets", [])
+        if snippets is None:
+            snippets = []
+        if not isinstance(snippets, list):
+            raise ValueError(f"record {item['record_id']} snippets must be a list")
+        records.append(
+            CompanyRecord(
+                record_id=record_id,
+                name=name,
+                document_id=item.get("document_id"),
+                snippets=[str(snippet) for snippet in snippets],
+                metadata={str(key): value for key, value in metadata.items()},
+            )
+        )
+    return records
+
+
+def write_result_json(result: ResolutionResult) -> str:
+    return json.dumps(result.to_dict(), indent=2, sort_keys=True)

--- a/src/entity_resolution/metadata.py
+++ b/src/entity_resolution/metadata.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Normalized access to metadata used by blocking, scoring, and clustering."""
+
+from .models import CompanyRecord
+from .normalization import normalize_domain, normalize_identifier
+
+
+def record_domain(record: CompanyRecord) -> str | None:
+    for key in ("domain", "website", "email_domain"):
+        if domain := normalize_domain(record.metadata.get(key)):
+            return domain
+    return None
+
+
+def record_registration(record: CompanyRecord) -> str | None:
+    for key in ("registration_number", "tax_id"):
+        if identifier := normalize_identifier(record.metadata.get(key)):
+            return identifier
+    return None
+
+
+def record_address(record: CompanyRecord) -> str | None:
+    return normalize_identifier(record.metadata.get("address"))

--- a/src/entity_resolution/models.py
+++ b/src/entity_resolution/models.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""Small immutable data contracts used by the resolver pipeline."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CompanyRecord:
+    record_id: str
+    name: str
+    document_id: str | None = None
+    snippets: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CompanyNameForms:
+    raw: str
+    normalized: str
+    core: str
+    tokens: tuple[str, ...]
+    sorted_tokens: str
+
+
+@dataclass(frozen=True)
+class ResolverConfig:
+    auto_merge_threshold: float = 0.92
+    review_threshold: float = 0.68
+
+
+@dataclass(frozen=True)
+class CompanyCandidate:
+    left_record_id: str
+    right_record_id: str
+    score: float
+    tier: str
+    evidence: tuple[str, ...] = ()
+    conflicts: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "left_record_id": self.left_record_id,
+            "right_record_id": self.right_record_id,
+            "score": round(self.score, 6),
+            "tier": self.tier,
+            "evidence": list(self.evidence),
+            "conflicts": list(self.conflicts),
+        }
+
+
+@dataclass(frozen=True)
+class DuplicateNameReport:
+    report_id: str
+    status: str
+    user_review_required: bool
+    names: tuple[str, ...]
+    record_ids: tuple[str, ...]
+    document_ids: tuple[str, ...]
+    evidence: tuple[str, ...] = ()
+    conflicts: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "report_id": self.report_id,
+            "status": self.status,
+            "user_review_required": self.user_review_required,
+            "names": list(self.names),
+            "record_ids": list(self.record_ids),
+            "document_ids": list(self.document_ids),
+            "evidence": list(self.evidence),
+            "conflicts": list(self.conflicts),
+        }
+
+
+@dataclass(frozen=True)
+class CompanyCluster:
+    cluster_id: str
+    canonical_name: str
+    aliases: tuple[str, ...]
+    member_record_ids: tuple[str, ...]
+    supporting_metadata: dict[str, Any] = field(default_factory=dict)
+    evidence_notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cluster_id": self.cluster_id,
+            "canonical_name": self.canonical_name,
+            "aliases": list(self.aliases),
+            "member_record_ids": list(self.member_record_ids),
+            "supporting_metadata": self.supporting_metadata,
+            "evidence_notes": list(self.evidence_notes),
+        }
+
+
+@dataclass(frozen=True)
+class ResolutionResult:
+    clusters: tuple[CompanyCluster, ...] = ()
+    auto_matches: tuple[CompanyCandidate, ...] = ()
+    duplicate_name_reports: tuple[DuplicateNameReport, ...] = ()
+    review_candidates: tuple[CompanyCandidate, ...] = ()
+    rejected_candidates: tuple[CompanyCandidate, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "clusters": [cluster.to_dict() for cluster in self.clusters],
+            "auto_matches": [candidate.to_dict() for candidate in self.auto_matches],
+            "duplicate_name_reports": [report.to_dict() for report in self.duplicate_name_reports],
+            "review_candidates": [candidate.to_dict() for candidate in self.review_candidates],
+            "rejected_candidates": [candidate.to_dict() for candidate in self.rejected_candidates],
+        }

--- a/src/entity_resolution/normalization.py
+++ b/src/entity_resolution/normalization.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Deterministic normalization helpers for names and matching metadata."""
+
+import re
+import unicodedata
+from urllib.parse import urlparse
+
+from .models import CompanyNameForms
+
+
+LEGAL_SUFFIXES = {
+    "co",
+    "company",
+    "corp",
+    "corporation",
+    "gmbh",
+    "inc",
+    "incorporated",
+    "limited",
+    "llc",
+    "llp",
+    "ltd",
+    "plc",
+    "sa",
+}
+
+CONNECTORS = {"and"}
+
+SINGULARS = {
+    "chemicals": "chemical",
+    "petrochemicals": "petrochemical",
+    "technologies": "technology",
+    "solutions": "solution",
+    "energies": "energy",
+}
+
+
+def _ascii_fold(value: str) -> str:
+    return unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+
+
+def _fold_name(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value).casefold()
+    return "".join(character for character in decomposed if not unicodedata.combining(character))
+
+
+def _clean_tokens(value: str) -> list[str]:
+    folded = _fold_name(value).replace("&", " and ")
+    cleaned = re.sub(r"[^\w]+", " ", folded, flags=re.UNICODE).replace("_", " ")
+    return [SINGULARS.get(token, token) for token in cleaned.split()]
+
+
+def normalize_company_name(name: str) -> CompanyNameForms:
+    tokens = _clean_tokens(name)
+    normalized_tokens = [token for token in tokens if token not in CONNECTORS]
+    core_tokens = [token for token in normalized_tokens if token not in LEGAL_SUFFIXES]
+    normalized = " ".join(normalized_tokens)
+    core = " ".join(core_tokens)
+    return CompanyNameForms(
+        raw=name,
+        normalized=normalized,
+        core=core,
+        tokens=tuple(core_tokens),
+        sorted_tokens=" ".join(sorted(core_tokens)),
+    )
+
+
+def company_initials(tokens: tuple[str, ...]) -> str | None:
+    if len(tokens) == 1 and 3 <= len(tokens[0]) <= 8:
+        return tokens[0] if tokens[0].isalpha() else None
+    if len(tokens) >= 3:
+        if any(not token.isalpha() for token in tokens):
+            return None
+        initials = "".join(token[0] for token in tokens if token)
+        return initials if 3 <= len(initials) <= 8 else None
+    return None
+
+
+def normalize_identifier(value: object) -> str | None:
+    if value is None:
+        return None
+    cleaned = re.sub(r"[^a-z0-9]+", "", _ascii_fold(str(value)).lower())
+    return cleaned or None
+
+
+def normalize_domain(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    if "@" in text and not text.startswith(("http://", "https://")):
+        text = text.rsplit("@", 1)[-1]
+    if "://" not in text:
+        text = "http://" + text
+    try:
+        parsed = urlparse(text)
+        host = parsed.hostname or parsed.path.split("/", 1)[0]
+    except ValueError:
+        return None
+    host = host.removeprefix("www.").rstrip(".")
+    return host or None

--- a/src/entity_resolution/person_io.py
+++ b/src/entity_resolution/person_io.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+"""Validated JSON boundaries for person connection screening."""
+
+import json
+
+from .person_models import PersonAttribute, PersonRecord, PersonResolutionResult
+from .person_normalization import normalize_person_name
+
+
+_MISSING = object()
+
+
+def _reject_duplicate_object_keys(pairs: list[tuple[object, object]]) -> dict[object, object]:
+    result: dict[object, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _required_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    return value
+
+
+def _optional_string(value: object, field_name: str) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    raise ValueError(f"{field_name} must be a string or null")
+
+
+def load_person_records_json(payload: str) -> list[PersonRecord]:
+    data = json.loads(payload, object_pairs_hook=_reject_duplicate_object_keys)
+    if not isinstance(data, list):
+        raise ValueError("input must be a JSON array")
+    records: list[PersonRecord] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ValueError(f"record at index {index} must be an object")
+        raw_record_id = item.get("record_id", _MISSING)
+        if raw_record_id is _MISSING:
+            raise ValueError(f"record at index {index} is missing required field record_id")
+        record_id = _required_string(raw_record_id, f"record at index {index} record_id").strip()
+        if not record_id:
+            raise ValueError(f"record at index {index} is missing required field record_id")
+        if record_id in seen_ids:
+            raise ValueError(f"duplicate record_id: {record_id}")
+        seen_ids.add(record_id)
+        raw_name = item.get("name", _MISSING)
+        if raw_name is _MISSING:
+            raise ValueError(f"record at index {index} is missing required field name")
+        name = _required_string(raw_name, f"record at index {index} name").strip()
+        if not name or not normalize_person_name(name).normalized:
+            raise ValueError(f"record at index {index} is missing required field name")
+        snippets = item.get("snippets", [])
+        if not isinstance(snippets, list):
+            raise ValueError(f"record {record_id} snippets must be a list")
+        normalized_snippets: list[str] = []
+        for snippet_index, snippet in enumerate(snippets):
+            if not isinstance(snippet, str):
+                raise ValueError(f"record {record_id} snippet {snippet_index} must be a string")
+            normalized_snippets.append(snippet)
+        raw_attributes = item.get("attributes", [])
+        if not isinstance(raw_attributes, list):
+            raise ValueError(f"record {record_id} attributes must be a list")
+        attributes: list[PersonAttribute] = []
+        for attribute_index, raw in enumerate(raw_attributes):
+            if not isinstance(raw, dict):
+                raise ValueError(f"record {record_id} attribute {attribute_index} must be an object")
+            raw_kind = raw.get("kind", _MISSING)
+            if raw_kind is _MISSING:
+                raise ValueError(f"record {record_id} attribute kind is required")
+            kind = _required_string(
+                raw_kind,
+                f"record {record_id} attribute kind",
+            ).strip().casefold()
+            raw_value = raw.get("value", _MISSING)
+            if raw_value is _MISSING:
+                raise ValueError(f"record {record_id} attribute value is required")
+            value = _required_string(
+                raw_value,
+                f"record {record_id} attribute value",
+            ).strip()
+            if not kind:
+                raise ValueError(f"record {record_id} attribute kind is required")
+            if not value:
+                raise ValueError(f"record {record_id} attribute value is required")
+            verified = raw.get("verified", False)
+            if not isinstance(verified, bool):
+                raise ValueError(f"record {record_id} attribute verified must be a boolean")
+            qualifiers = raw.get("qualifiers", {})
+            if not isinstance(qualifiers, dict):
+                raise ValueError(f"record {record_id} attribute qualifiers must be an object")
+            normalized_qualifiers: list[tuple[str, str]] = []
+            for key, qualifier_value in qualifiers.items():
+                if not isinstance(key, str):
+                    raise ValueError(f"record {record_id} attribute qualifier key must be a string")
+                if not isinstance(qualifier_value, str):
+                    raise ValueError(
+                        f"record {record_id} attribute qualifier {key!r} must be a string"
+                    )
+                normalized_qualifiers.append((key, qualifier_value))
+            attributes.append(
+                PersonAttribute(
+                    kind=kind,
+                    value=value,
+                    source_document_id=_optional_string(
+                        raw.get("source_document_id"), "source_document_id"
+                    ),
+                    effective_from=_optional_string(raw.get("effective_from"), "effective_from"),
+                    effective_to=_optional_string(raw.get("effective_to"), "effective_to"),
+                    verified=verified,
+                    notes=_optional_string(raw.get("notes"), "notes"),
+                    qualifiers=tuple(sorted(normalized_qualifiers)),
+                )
+            )
+        records.append(
+            PersonRecord(
+                record_id=record_id,
+                name=name,
+                document_id=_optional_string(item.get("document_id"), "document_id"),
+                snippets=tuple(normalized_snippets),
+                attributes=tuple(attributes),
+            )
+        )
+    return records
+
+
+def write_person_result_json(result: PersonResolutionResult) -> str:
+    return json.dumps(result.to_dict(), indent=2, sort_keys=True)

--- a/src/entity_resolution/person_models.py
+++ b/src/entity_resolution/person_models.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+"""Immutable contracts for conservative person connection screening."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PersonAttribute:
+    kind: str
+    value: str
+    source_document_id: str | None = None
+    effective_from: str | None = None
+    effective_to: str | None = None
+    verified: bool = False
+    notes: str | None = None
+    qualifiers: tuple[tuple[str, str], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "value": self.value,
+            "source_document_id": self.source_document_id,
+            "effective_from": self.effective_from,
+            "effective_to": self.effective_to,
+            "verified": self.verified,
+            "notes": self.notes,
+            "qualifiers": dict(self.qualifiers),
+        }
+
+
+@dataclass(frozen=True)
+class PersonRecord:
+    record_id: str
+    name: str
+    document_id: str | None = None
+    snippets: tuple[str, ...] = ()
+    attributes: tuple[PersonAttribute, ...] = ()
+
+
+@dataclass(frozen=True)
+class PersonNameForms:
+    raw: str
+    normalized: str
+    tokens: tuple[str, ...]
+    sorted_tokens: str
+
+
+@dataclass(frozen=True)
+class PersonEvidence:
+    kind: str
+    relationship: str
+    left_values: tuple[str, ...]
+    right_values: tuple[str, ...]
+    score_contribution: float
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "relationship": self.relationship,
+            "left_values": list(self.left_values),
+            "right_values": list(self.right_values),
+            "score_contribution": round(self.score_contribution, 6),
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class PersonProfile:
+    profile_id: str
+    canonical_name: str
+    names: tuple[str, ...]
+    member_record_ids: tuple[str, ...]
+    document_ids: tuple[str, ...]
+    snippets: tuple[str, ...]
+    attributes: tuple[PersonAttribute, ...]
+    confirmed_by: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile_id": self.profile_id,
+            "canonical_name": self.canonical_name,
+            "names": list(self.names),
+            "member_record_ids": list(self.member_record_ids),
+            "document_ids": list(self.document_ids),
+            "snippets": list(self.snippets),
+            "attributes": [attribute.to_dict() for attribute in self.attributes],
+            "confirmed_by": list(self.confirmed_by),
+        }
+
+
+@dataclass(frozen=True)
+class PersonAutoMatch:
+    left_record_id: str
+    right_record_id: str
+    matching_verified_government_ids: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "left_record_id": self.left_record_id,
+            "right_record_id": self.right_record_id,
+            "matching_verified_government_ids": list(self.matching_verified_government_ids),
+        }
+
+
+@dataclass(frozen=True)
+class UncertainConnection:
+    connection_id: str
+    status: str
+    human_or_llm_review_required: bool
+    left: PersonProfile
+    right: PersonProfile
+    score: float
+    evidence: tuple[PersonEvidence, ...]
+    conflicts: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "connection_id": self.connection_id,
+            "status": self.status,
+            "human_or_llm_review_required": self.human_or_llm_review_required,
+            "left": self.left.to_dict(),
+            "right": self.right.to_dict(),
+            "score": round(self.score, 6),
+            "evidence": [item.to_dict() for item in self.evidence],
+            "conflicts": list(self.conflicts),
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class PersonResolutionResult:
+    confirmed_profiles: tuple[PersonProfile, ...] = ()
+    auto_matches: tuple[PersonAutoMatch, ...] = ()
+    uncertain_connections: tuple[UncertainConnection, ...] = ()
+    screened_out_profile_pairs: tuple[tuple[str, str], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "confirmed_profiles": [profile.to_dict() for profile in self.confirmed_profiles],
+            "auto_matches": [match.to_dict() for match in self.auto_matches],
+            "uncertain_connections": [connection.to_dict() for connection in self.uncertain_connections],
+            "screened_out_profile_pairs": [list(pair) for pair in self.screened_out_profile_pairs],
+        }

--- a/src/entity_resolution/person_normalization.py
+++ b/src/entity_resolution/person_normalization.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+"""Conservative normalization for person names and sourced attributes."""
+
+from datetime import date
+from difflib import SequenceMatcher
+import json
+import re
+import unicodedata
+
+from .person_models import PersonAttribute, PersonNameForms
+
+
+RECOGNIZED_ATTRIBUTE_KINDS = frozenset(
+    {
+        "government_id",
+        "birth_date",
+        "email",
+        "phone",
+        "residence",
+        "birthplace",
+        "workplace",
+        "profession",
+        "nationality",
+        "gender",
+        "family_member",
+        "alias",
+    }
+)
+
+
+def canonicalize_person_attribute_kind(kind: str) -> str:
+    return kind.strip().casefold()
+
+
+def _fold_text(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value).casefold()
+    without_marks = "".join(
+        character for character in decomposed if not unicodedata.combining(character)
+    )
+    return " ".join(
+        re.sub(r"[^\w]+", " ", without_marks, flags=re.UNICODE).replace("_", " ").split()
+    )
+
+
+def _compact_alphanumeric(value: str) -> str:
+    return "".join(character for character in _fold_text(value) if character.isalnum())
+
+
+def _normalize_government_id_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFC", value)
+    return "".join(
+        character
+        for character in normalized
+        if character.isalnum() or unicodedata.category(character).startswith("M")
+    )
+
+
+def normalize_person_name(name: str) -> PersonNameForms:
+    normalized = _fold_text(name)
+    tokens = tuple(normalized.split())
+    return PersonNameForms(
+        raw=name,
+        normalized=normalized,
+        tokens=tokens,
+        sorted_tokens=" ".join(sorted(tokens)),
+    )
+
+
+def normalize_person_attribute(attribute: PersonAttribute) -> str:
+    kind = canonicalize_person_attribute_kind(attribute.kind)
+    value = attribute.value.strip()
+    if kind == "email":
+        return value.casefold()
+    if kind == "phone":
+        return _compact_alphanumeric(value)
+    if kind == "government_id":
+        return _normalize_government_id_text(value)
+    if kind == "birth_date":
+        try:
+            return date.fromisoformat(value).isoformat()
+        except ValueError:
+            return _fold_text(value)
+    if kind == "alias":
+        return normalize_person_name(value).normalized
+    return _fold_text(value)
+
+
+def government_id_components(attribute: PersonAttribute) -> tuple[str, str, str] | None:
+    if canonicalize_person_attribute_kind(attribute.kind) != "government_id" or not attribute.verified:
+        return None
+    qualifiers: dict[str, str] = {}
+    for key, value in attribute.qualifiers:
+        canonical_key = key.strip().casefold()
+        canonical_value = value.strip().casefold()
+        if canonical_key in {"issuer", "identifier_type"}:
+            if canonical_key in qualifiers and qualifiers[canonical_key] != canonical_value:
+                return None
+        qualifiers[canonical_key] = canonical_value
+    issuer = qualifiers.get("issuer")
+    identifier_type = qualifiers.get("identifier_type")
+    identifier = normalize_person_attribute(attribute)
+    if not issuer or not identifier_type or not identifier:
+        return None
+    return issuer, identifier_type, identifier
+
+
+def government_id_key(attribute: PersonAttribute) -> str | None:
+    if components := government_id_components(attribute):
+        return json.dumps(components, ensure_ascii=False, separators=(",", ":"))
+    return None
+
+
+def person_name_similarity(left: str, right: str) -> float:
+    left_forms = normalize_person_name(left)
+    right_forms = normalize_person_name(right)
+    if not left_forms.normalized or not right_forms.normalized:
+        return 0.0
+    direct = SequenceMatcher(None, left_forms.normalized, right_forms.normalized).ratio()
+    reordered = SequenceMatcher(None, left_forms.sorted_tokens, right_forms.sorted_tokens).ratio()
+    return max(direct, reordered)

--- a/src/entity_resolution/person_normalization.py
+++ b/src/entity_resolution/person_normalization.py
@@ -118,4 +118,31 @@ def person_name_similarity(left: str, right: str) -> float:
         return 0.0
     direct = SequenceMatcher(None, left_forms.normalized, right_forms.normalized).ratio()
     reordered = SequenceMatcher(None, left_forms.sorted_tokens, right_forms.sorted_tokens).ratio()
-    return max(direct, reordered)
+    aligned = _aligned_token_similarity(left_forms.tokens, right_forms.tokens)
+    return max(direct, reordered, aligned)
+
+
+def _aligned_token_similarity(left_tokens: tuple[str, ...], right_tokens: tuple[str, ...]) -> float:
+    """Match reordered tokens while treating an initial as its full-name equivalent."""
+    if not left_tokens or not right_tokens:
+        return 0.0
+    shorter, remaining = sorted(
+        (left_tokens, right_tokens), key=lambda tokens: (len(tokens), tokens),
+    )
+    remaining = list(remaining)
+    scores: list[float] = []
+    # Long tokens match first so a surname is not consumed by a one-letter initial.
+    for token in sorted(shorter, key=lambda item: (-len(item), item)):
+        options = [
+            (
+                1.0 if token == candidate else
+                0.95 if min(len(token), len(candidate)) == 1 and token[0] == candidate[0] else
+                SequenceMatcher(None, token, candidate).ratio(),
+                index,
+            )
+            for index, candidate in enumerate(remaining)
+        ]
+        score, index = max(options)
+        scores.append(score)
+        remaining.pop(index)
+    return sum(scores) / max(len(left_tokens), len(right_tokens))

--- a/src/entity_resolution/person_resolver.py
+++ b/src/entity_resolution/person_resolver.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+"""Conservative person aggregation and connection screening."""
+
+from collections import defaultdict
+from collections.abc import Iterable
+import hashlib
+import json
+from itertools import combinations
+
+from .person_models import (
+    PersonAttribute,
+    PersonAutoMatch,
+    PersonEvidence,
+    PersonProfile,
+    PersonRecord,
+    PersonResolutionResult,
+    UncertainConnection,
+)
+from .person_normalization import (
+    canonicalize_person_attribute_kind,
+    government_id_components,
+    government_id_key,
+    normalize_person_attribute,
+    normalize_person_name,
+    person_name_similarity,
+)
+
+
+MAX_CONTEXT_BLOCK_SIZE = 500
+CONNECTION_THRESHOLD = 0.30
+
+
+class _UnionFind:
+    def __init__(self, record_ids: Iterable[str]) -> None:
+        self.parent = {record_id: record_id for record_id in record_ids}
+
+    def find(self, item: str) -> str:
+        if self.parent[item] != item:
+            self.parent[item] = self.find(self.parent[item])
+        return self.parent[item]
+
+    def union(self, left: str, right: str) -> None:
+        left_root, right_root = self.find(left), self.find(right)
+        if left_root != right_root:
+            winner, loser = sorted((left_root, right_root))
+            self.parent[loser] = winner
+
+
+def _stable_id(prefix: str, values: Iterable[str]) -> str:
+    digest = hashlib.sha1(
+        json.dumps(sorted(values), ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"{prefix}_{digest}"
+
+
+def _attribute_sort_key(attribute: PersonAttribute) -> tuple[object, ...]:
+    return (
+        canonicalize_person_attribute_kind(attribute.kind),
+        normalize_person_attribute(attribute),
+        attribute.value,
+        attribute.source_document_id or "",
+        attribute.effective_from or "",
+        attribute.effective_to or "",
+        attribute.verified,
+        attribute.notes or "",
+        attribute.qualifiers,
+    )
+
+
+def _verified_ids(record: PersonRecord) -> set[str]:
+    return {key for attribute in record.attributes if (key := government_id_key(attribute))}
+
+
+def _verified_values(entity: PersonRecord | PersonProfile, kind: str) -> set[str]:
+    kind = canonicalize_person_attribute_kind(kind)
+    return {
+        normalize_person_attribute(attribute)
+        for attribute in entity.attributes
+        if canonicalize_person_attribute_kind(attribute.kind) == kind
+        and attribute.verified
+        and normalize_person_attribute(attribute)
+    }
+
+
+def _entity_names(entity: PersonRecord | PersonProfile) -> tuple[str, ...]:
+    primary_names = entity.names if isinstance(entity, PersonProfile) else (entity.name,)
+    aliases = tuple(
+        attribute.value
+        for attribute in entity.attributes
+        if canonicalize_person_attribute_kind(attribute.kind) == "alias"
+    )
+    return primary_names + aliases
+
+
+def _names_compatible(left: PersonRecord | PersonProfile, right: PersonRecord | PersonProfile) -> bool:
+    left_names = _entity_names(left)
+    right_names = _entity_names(right)
+    return any(person_name_similarity(left_name, right_name) >= 0.82 for left_name in left_names for right_name in right_names)
+
+
+def _verified_identity_conflicts(
+    entities: Iterable[PersonRecord | PersonProfile],
+) -> tuple[str, ...]:
+    entities = tuple(entities)
+    conflicts: list[str] = []
+    verified_birth_dates = {
+        value
+        for entity in entities
+        for value in _verified_values(entity, "birth_date")
+    }
+    if len(verified_birth_dates) > 1:
+        conflicts.append("verified_birth_date_conflict")
+
+    identifiers_by_scheme: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for entity in entities:
+        for attribute in entity.attributes:
+            components = government_id_components(attribute)
+            if components is None:
+                continue
+            issuer, identifier_type, identifier = components
+            identifiers_by_scheme[(issuer, identifier_type)].add(identifier)
+    if any(len(identifiers) > 1 for identifiers in identifiers_by_scheme.values()):
+        conflicts.append("competing_verified_government_ids")
+    return tuple(conflicts)
+
+
+def _pair_conflicts(left: PersonRecord, right: PersonRecord) -> tuple[str, ...]:
+    conflicts = list(_verified_identity_conflicts((left, right)))
+    if set(_verified_ids(left)) & set(_verified_ids(right)) and not _names_compatible(left, right):
+        conflicts.append("incompatible_names_on_shared_government_id")
+    return tuple(conflicts)
+
+
+def _group_conflicts(records: Iterable[PersonRecord]) -> tuple[str, ...]:
+    records = tuple(records)
+    conflicts = list(_verified_identity_conflicts(records))
+    if any(not _names_compatible(left, right) for left, right in combinations(records, 2)):
+        conflicts.append("incompatible_names_on_shared_government_id")
+    return tuple(conflicts)
+
+
+def _profile(records: list[PersonRecord], confirmed_by: Iterable[str]) -> PersonProfile:
+    member_ids = tuple(sorted(record.record_id for record in records))
+    names = tuple(sorted({record.name for record in records}, key=lambda value: (value.casefold(), value)))
+    attributes = tuple(sorted({attribute for record in records for attribute in record.attributes}, key=_attribute_sort_key))
+    document_ids = tuple(sorted({record.document_id for record in records if record.document_id}))
+    snippets = tuple(sorted({snippet for record in records for snippet in record.snippets}))
+    canonical_name = sorted(names, key=lambda value: (-len(normalize_person_name(value).tokens), -len(value), value.casefold(), value))[0]
+    return PersonProfile(
+        profile_id=_stable_id("person_profile", member_ids),
+        canonical_name=canonical_name,
+        names=names,
+        member_record_ids=member_ids,
+        document_ids=document_ids,
+        snippets=snippets,
+        attributes=attributes,
+        confirmed_by=tuple(sorted(set(confirmed_by))),
+    )
+
+
+def _connection(
+    left: PersonProfile,
+    right: PersonProfile,
+    score: float,
+    evidence: Iterable[PersonEvidence],
+    conflicts: Iterable[str],
+    warnings: Iterable[str],
+) -> UncertainConnection:
+    ordered_left, ordered_right = sorted((left, right), key=lambda profile: profile.profile_id)
+    return UncertainConnection(
+        connection_id=_stable_id("person_connection", (ordered_left.profile_id, ordered_right.profile_id)),
+        status="uncertain_connection",
+        human_or_llm_review_required=True,
+        left=ordered_left,
+        right=ordered_right,
+        score=max(0.0, min(1.0, score)),
+        evidence=tuple(evidence),
+        conflicts=tuple(sorted(set(conflicts))),
+        warnings=tuple(sorted(set(warnings))),
+    )
+
+
+def _profile_values(profile: PersonProfile, kind: str) -> tuple[str, ...]:
+    kind = canonicalize_person_attribute_kind(kind)
+    return tuple(sorted({
+        normalize_person_attribute(attribute)
+        for attribute in profile.attributes
+        if canonicalize_person_attribute_kind(attribute.kind) == kind and normalize_person_attribute(attribute)
+    }))
+
+
+def _shared_values(left: PersonProfile, right: PersonProfile, kind: str) -> tuple[str, ...]:
+    return tuple(sorted(set(_profile_values(left, kind)) & set(_profile_values(right, kind))))
+
+
+def _profile_government_ids(profile: PersonProfile) -> tuple[str, ...]:
+    return tuple(sorted({
+        identifier
+        for attribute in profile.attributes
+        if (identifier := government_id_key(attribute))
+    }))
+
+
+def _identity_warning_needed(
+    shared_government_ids: tuple[str, ...],
+    conflicts: Iterable[str],
+) -> bool:
+    conflict_set = set(conflicts)
+    return bool(shared_government_ids and conflict_set) or (
+        "competing_verified_government_ids" in conflict_set
+    )
+
+
+def _name_evidence(left: PersonProfile, right: PersonProfile) -> PersonEvidence | None:
+    pairs = [
+        (person_name_similarity(left_name, right_name), left_name, right_name)
+        for left_name in left.names
+        for right_name in right.names
+    ]
+    similarity, left_name, right_name = max(pairs)
+    left_forms = normalize_person_name(left_name)
+    right_forms = normalize_person_name(right_name)
+    if left_forms.normalized == right_forms.normalized:
+        relationship, contribution, detail = "exact_match", 0.55, "Exact normalized name; common names remain ambiguous"
+    elif left_forms.sorted_tokens == right_forms.sorted_tokens:
+        relationship, contribution, detail = "reordered_match", 0.50, "Same normalized name tokens in a different order"
+    elif similarity >= 0.82:
+        relationship, contribution, detail = "similar", 0.35, f"Name similarity {similarity:.3f}"
+    else:
+        return None
+    return PersonEvidence("name", relationship, (left_name,), (right_name,), contribution, detail)
+
+
+ATTRIBUTE_WEIGHTS = {
+    "birth_date": 0.30,
+    "email": 0.35,
+    "phone": 0.35,
+    "residence": 0.18,
+    "birthplace": 0.15,
+    "workplace": 0.15,
+    "profession": 0.08,
+    "nationality": 0.05,
+    "gender": 0.02,
+    "family_member": 0.25,
+    "alias": 0.45,
+}
+
+
+def _family_reference_evidence(left: PersonProfile, right: PersonProfile) -> PersonEvidence | None:
+    left_family = set(_profile_values(left, "family_member"))
+    right_family = set(_profile_values(right, "family_member"))
+    left_names = {normalize_person_name(name).normalized for name in left.names}
+    right_names = {normalize_person_name(name).normalized for name in right.names}
+    left_references = tuple(sorted(left_family & right_names))
+    right_references = tuple(sorted(right_family & left_names))
+    if not left_references and not right_references:
+        return None
+    return PersonEvidence(
+        kind="family_member",
+        relationship="declared_reference",
+        left_values=left_references,
+        right_values=right_references,
+        score_contribution=ATTRIBUTE_WEIGHTS["family_member"],
+        detail="At least one profile names the other person as a family member; the relationship itself is not inferred",
+    )
+
+
+def _attribute_evidence(left: PersonProfile, right: PersonProfile) -> tuple[PersonEvidence, ...]:
+    evidence: list[PersonEvidence] = []
+    for kind, contribution in ATTRIBUTE_WEIGHTS.items():
+        if kind == "family_member":
+            continue
+        shared = _shared_values(left, right, kind)
+        if shared:
+            evidence.append(PersonEvidence(
+                kind=kind,
+                relationship="exact_normalized_match",
+                left_values=shared,
+                right_values=shared,
+                score_contribution=contribution,
+                detail=f"Shared normalized {kind} value",
+            ))
+    if family_reference := _family_reference_evidence(left, right):
+        evidence.append(family_reference)
+    shared_government_ids = tuple(sorted(set(_profile_government_ids(left)) & set(_profile_government_ids(right))))
+    if shared_government_ids:
+        evidence.append(PersonEvidence(
+            kind="government_id",
+            relationship="exact_verified_match",
+            left_values=shared_government_ids,
+            right_values=shared_government_ids,
+            score_contribution=0.0,
+            detail="Same verified, issuer-qualified government identifier; conflict prevents automatic aggregation",
+        ))
+    return tuple(evidence)
+
+
+def _blocking_keys(profile: PersonProfile) -> set[str]:
+    keys: set[str] = set()
+    for name in profile.names:
+        forms = normalize_person_name(name)
+        if forms.normalized:
+            keys.add("name:" + forms.normalized)
+            keys.add("sorted_name:" + forms.sorted_tokens)
+        for token in forms.tokens:
+            if len(token) >= 3:
+                keys.add("name_token:" + token)
+                keys.add("name_prefix:" + token[:4])
+    for kind in (*ATTRIBUTE_WEIGHTS, "government_id"):
+        for value in _profile_values(profile, kind):
+            keys.add(f"{kind}:{value}")
+    return keys
+
+
+def generate_person_candidate_pairs(profiles: Iterable[PersonProfile]) -> list[tuple[str, str]]:
+    blocks: dict[str, list[str]] = defaultdict(list)
+    for profile in profiles:
+        for key in _blocking_keys(profile):
+            blocks[key].append(profile.profile_id)
+    pairs: set[tuple[str, str]] = set()
+    for key, profile_ids in blocks.items():
+        unique = sorted(set(profile_ids))
+        block_kind = key.split(":", 1)[0]
+        if len(unique) > MAX_CONTEXT_BLOCK_SIZE and block_kind not in {"government_id", "email", "phone"}:
+            continue
+        for index, left_id in enumerate(unique):
+            for right_id in unique[index + 1:]:
+                pairs.add((left_id, right_id))
+    return sorted(pairs)
+
+
+def _screen_profile_pair(left: PersonProfile, right: PersonProfile) -> UncertainConnection | None:
+    evidence = list(_attribute_evidence(left, right))
+    if name_item := _name_evidence(left, right):
+        evidence.insert(0, name_item)
+    context_items = [item for item in evidence if item.kind not in {"name", "nationality", "gender", "profession"}]
+    score = sum(item.score_contribution for item in evidence)
+    has_name_signal = any(item.kind == "name" for item in evidence)
+    has_two_context_signals = len(context_items) >= 2
+    if score < CONNECTION_THRESHOLD or not (has_name_signal or has_two_context_signals):
+        return None
+
+    conflicts = list(_verified_identity_conflicts((left, right)))
+    shared_government_ids = tuple(sorted(set(_profile_government_ids(left)) & set(_profile_government_ids(right))))
+
+    warnings = ["similarities_may_reflect_family_household_marriage_colleagues_or_coincidence"]
+    if _identity_warning_needed(shared_government_ids, conflicts):
+        warnings.append("possible_identity_misuse_or_data_error")
+    return _connection(left, right, score, evidence, conflicts, warnings)
+
+
+def resolve_people(records: Iterable[PersonRecord]) -> PersonResolutionResult:
+    ordered_records = sorted(records, key=lambda record: record.record_id)
+    if len({record.record_id for record in ordered_records}) != len(ordered_records):
+        raise ValueError("record_id values must be unique")
+    records_by_id = {record.record_id: record for record in ordered_records}
+    id_blocks: dict[str, list[str]] = defaultdict(list)
+    for record in ordered_records:
+        for identifier in _verified_ids(record):
+            id_blocks[identifier].append(record.record_id)
+
+    proposed_pairs = sorted({
+        (left_id, right_id, identifier)
+        for identifier, record_ids in id_blocks.items()
+        for index, left_id in enumerate(sorted(set(record_ids)))
+        for right_id in sorted(set(record_ids))[index + 1:]
+    })
+    union_find = _UnionFind(records_by_id)
+    auto_matches: list[PersonAutoMatch] = []
+    rejected_id_pairs: list[tuple[str, str, str, tuple[str, ...]]] = []
+    for left_id, right_id, identifier in proposed_pairs:
+        left, right = records_by_id[left_id], records_by_id[right_id]
+        left_root, right_root = union_find.find(left_id), union_find.find(right_id)
+        prospective_records = [
+            record
+            for record in ordered_records
+            if union_find.find(record.record_id) in {left_root, right_root}
+        ]
+        conflicts = tuple(dict.fromkeys((*_pair_conflicts(left, right), *_group_conflicts(prospective_records))))
+        if conflicts:
+            rejected_id_pairs.append((left_id, right_id, identifier, conflicts))
+            continue
+        union_find.union(left_id, right_id)
+        auto_matches.append(PersonAutoMatch(left_id, right_id, (identifier,)))
+
+    groups: dict[str, list[PersonRecord]] = defaultdict(list)
+    for record in ordered_records:
+        groups[union_find.find(record.record_id)].append(record)
+    profiles = []
+    for group in groups.values():
+        confirmed_by = (
+            (identifier for record in group for identifier in _verified_ids(record))
+            if len(group) > 1
+            else ()
+        )
+        profiles.append(_profile(group, confirmed_by))
+    profiles.sort(key=lambda profile: profile.profile_id)
+    confirmed_profiles = tuple(profile for profile in profiles if len(profile.member_record_ids) > 1)
+
+    profile_by_record_id = {
+        record_id: profile
+        for profile in profiles
+        for record_id in profile.member_record_ids
+    }
+    profiles_by_id = {profile.profile_id: profile for profile in profiles}
+    rejected_pairs_by_profile_pair: dict[tuple[str, str], list[tuple[str, tuple[str, ...]]]] = defaultdict(list)
+    for left_id, right_id, identifier, conflicts in rejected_id_pairs:
+        left_profile = profile_by_record_id[left_id]
+        right_profile = profile_by_record_id[right_id]
+        if left_profile.profile_id == right_profile.profile_id:
+            continue
+        profile_pair = tuple(sorted((left_profile.profile_id, right_profile.profile_id)))
+        rejected_pairs_by_profile_pair[profile_pair].append((identifier, conflicts))
+
+    forced_connections = []
+    for left_profile_id, right_profile_id in sorted(rejected_pairs_by_profile_pair):
+        rejected_items = sorted(rejected_pairs_by_profile_pair[(left_profile_id, right_profile_id)])
+        forced_connections.append(
+            _connection(
+                profiles_by_id[left_profile_id],
+                profiles_by_id[right_profile_id],
+                1.0,
+                tuple(
+                    PersonEvidence(
+                        "government_id",
+                        "exact_match",
+                        (identifier,),
+                        (identifier,),
+                        1.0,
+                        "Same verified government identifier",
+                    )
+                    for identifier, _ in rejected_items
+                ),
+                tuple(sorted({
+                    conflict
+                    for _, item_conflicts in rejected_items
+                    for conflict in item_conflicts
+                })),
+                ("possible_identity_misuse_or_data_error",),
+            )
+        )
+    connections_by_id = {connection.connection_id: connection for connection in forced_connections}
+    forced_connection_pairs = {
+        tuple(sorted((connection.left.profile_id, connection.right.profile_id)))
+        for connection in forced_connections
+    }
+    screened_out: list[tuple[str, str]] = []
+    for left_id, right_id in generate_person_candidate_pairs(profiles):
+        if (left_id, right_id) in forced_connection_pairs:
+            continue
+        connection = _screen_profile_pair(profiles_by_id[left_id], profiles_by_id[right_id])
+        if connection is None:
+            screened_out.append((left_id, right_id))
+        else:
+            connections_by_id[connection.connection_id] = connection
+
+    return PersonResolutionResult(
+        confirmed_profiles=confirmed_profiles,
+        auto_matches=tuple(sorted(auto_matches, key=lambda match: (match.left_record_id, match.right_record_id))),
+        uncertain_connections=tuple(sorted(connections_by_id.values(), key=lambda item: item.connection_id)),
+        screened_out_profile_pairs=tuple(sorted(set(screened_out))),
+    )

--- a/src/entity_resolution/person_review.py
+++ b/src/entity_resolution/person_review.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Create auditable review prompts without calling an LLM."""
+
+import json
+
+from .person_models import UncertainConnection
+
+
+def generate_person_review_prompt(connection: UncertainConnection) -> str:
+    return (
+        "Review the uncertain connection between these person profiles. "
+        "This output is advisory only, a human reviewer must make the final decision, and the LLM is not an identity adjudicator. "
+        "Do not assume that a similar name, birth date, address, workplace, nationality, gender, profession, or family context proves identity. "
+        "Similarities may instead reflect relatives, marriage, a shared household, colleagues, coincidence, stale data, identity misuse, or source error. "
+        "Use only the supplied sourced information and preserve uncertainty. "
+        "Return strict JSON with keys decision, confidence, rationale, supporting_evidence, conflicts, and follow_up_needed. "
+        "decision must be one of same_person, connected_people, unrelated, uncertain.\n\n"
+        + json.dumps(connection.to_dict(), indent=2, sort_keys=True)
+    )

--- a/src/entity_resolution/resolver.py
+++ b/src/entity_resolution/resolver.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+"""Candidate blocking and deterministic union-find clustering."""
+
+import hashlib
+from dataclasses import replace
+from collections import defaultdict
+from collections.abc import Iterable
+
+from .metadata import record_address, record_domain, record_registration
+from .models import CompanyCandidate, CompanyCluster, CompanyRecord, DuplicateNameReport, ResolutionResult, ResolverConfig
+from .normalization import company_initials, normalize_company_name
+from .scoring import score_candidate
+from .token_stats import WEAK_WORDS, token_weights
+
+
+# ponytail: cap noisy blocks; exact/core blocks still provide the normal path.
+MAX_NOISY_BLOCK_SIZE = 500
+
+
+def _add_blocks(blocks: dict[str, list[str]], key: str, record_id: str) -> None:
+    if key:
+        blocks[key].append(record_id)
+
+
+def generate_candidate_pairs(records: Iterable[CompanyRecord]) -> list[tuple[str, str]]:
+    records_by_id = {record.record_id: record for record in records}
+    blocks: dict[str, list[str]] = defaultdict(list)
+    for record in records_by_id.values():
+        forms = normalize_company_name(record.name)
+        if forms.core:
+            _add_blocks(blocks, "core:" + forms.core, record.record_id)
+        if forms.sorted_tokens:
+            _add_blocks(blocks, "sorted:" + forms.sorted_tokens, record.record_id)
+        if forms.tokens and forms.tokens[0] not in WEAK_WORDS:
+            _add_blocks(blocks, "first:" + forms.tokens[0], record.record_id)
+        distinctive = [token for token in forms.tokens if token not in WEAK_WORDS]
+        for token in distinctive:
+            _add_blocks(blocks, "token:" + token, record.record_id)
+        if initials := company_initials(forms.tokens):
+            _add_blocks(blocks, "acronym:" + initials, record.record_id)
+        domain = record_domain(record)
+        if domain:
+            _add_blocks(blocks, "domain:" + domain, record.record_id)
+        registration = record_registration(record)
+        if registration:
+            _add_blocks(blocks, "registration:" + registration, record.record_id)
+        address = record_address(record)
+        if address:
+            _add_blocks(blocks, "address:" + address, record.record_id)
+
+    pairs: set[tuple[str, str]] = set()
+    for block_key, record_ids in blocks.items():
+        unique = sorted(set(record_ids))
+        if len(unique) < 2:
+            continue
+        if block_key.split(":", 1)[0] in {"first", "token", "domain", "address", "acronym"} and len(unique) > MAX_NOISY_BLOCK_SIZE:
+            continue
+        for index, left_id in enumerate(unique):
+            for right_id in unique[index + 1 :]:
+                pairs.add((left_id, right_id))
+    return sorted(pairs)
+
+
+class _UnionFind:
+    def __init__(self, ids: Iterable[str]) -> None:
+        self.parent = {record_id: record_id for record_id in ids}
+
+    def find(self, item: str) -> str:
+        parent = self.parent[item]
+        if parent != item:
+            self.parent[item] = self.find(parent)
+        return self.parent[item]
+
+    def union(self, left: str, right: str) -> None:
+        left_root = self.find(left)
+        right_root = self.find(right)
+        if left_root == right_root:
+            return
+        winner, loser = sorted((left_root, right_root))
+        self.parent[loser] = winner
+
+
+def _cluster_id(member_ids: tuple[str, ...]) -> str:
+    digest = hashlib.sha1("|".join(member_ids).encode("utf-8")).hexdigest()[:12]
+    return "cluster_" + digest
+
+
+def _canonical_name(records: list[CompanyRecord]) -> str:
+    return sorted((record.name for record in records), key=lambda value: (len(normalize_company_name(value).core), value.lower(), value))[0]
+
+
+def _supporting_metadata(records: list[CompanyRecord]) -> dict[str, object]:
+    domains = sorted({domain for record in records if (domain := record_domain(record))})
+    registrations = sorted({reg for record in records if (reg := record_registration(record))})
+    output: dict[str, object] = {}
+    if domains:
+        output["domains"] = domains
+    if registrations:
+        output["registration_numbers"] = registrations
+    return output
+
+
+def _report_id(status: str, record_ids: tuple[str, ...]) -> str:
+    digest = hashlib.sha1("|".join(record_ids).encode("utf-8")).hexdigest()[:12]
+    kind = "auto" if status == "auto_merged" else "review"
+    return f"duplicate_{kind}_{digest}"
+
+
+def _report(
+    status: str,
+    record_ids: tuple[str, ...],
+    records_by_id: dict[str, CompanyRecord],
+    evidence: Iterable[str],
+    conflicts: Iterable[str],
+) -> DuplicateNameReport:
+    names = tuple(sorted(
+        {records_by_id[record_id].name for record_id in record_ids},
+        key=lambda value: (value.lower(), value),
+    ))
+    document_ids = tuple(sorted({
+        document_id
+        for record_id in record_ids
+        if (document_id := records_by_id[record_id].document_id)
+    }))
+    return DuplicateNameReport(
+        report_id=_report_id(status, record_ids),
+        status=status,
+        user_review_required=status == "review_required",
+        names=names,
+        record_ids=record_ids,
+        document_ids=document_ids,
+        evidence=tuple(sorted(set(evidence))),
+        conflicts=tuple(sorted(set(conflicts))),
+    )
+
+
+def _duplicate_name_reports(
+    records_by_id: dict[str, CompanyRecord],
+    clusters: Iterable[CompanyCluster],
+    review_candidates: Iterable[CompanyCandidate],
+) -> tuple[DuplicateNameReport, ...]:
+    clusters = tuple(clusters)
+    review_candidates = tuple(review_candidates)
+    reports = [
+        _report(
+            "auto_merged",
+            cluster.member_record_ids,
+            records_by_id,
+            cluster.evidence_notes,
+            (),
+        )
+        for cluster in clusters
+    ]
+
+    review_ids = {
+        record_id
+        for candidate in review_candidates
+        for record_id in (candidate.left_record_id, candidate.right_record_id)
+    }
+    review_groups = _UnionFind(records_by_id)
+    for candidate in review_candidates:
+        review_groups.union(candidate.left_record_id, candidate.right_record_id)
+    # Include confirmed aliases in any review component they touch without
+    # turning the review candidate itself into an automatic cluster member.
+    for cluster in clusters:
+        if review_ids.intersection(cluster.member_record_ids):
+            first, *rest = cluster.member_record_ids
+            for record_id in rest:
+                review_groups.union(first, record_id)
+
+    grouped: dict[str, set[str]] = defaultdict(set)
+    for record_id in review_ids:
+        grouped[review_groups.find(record_id)].add(record_id)
+    for cluster in clusters:
+        roots = {review_groups.find(record_id) for record_id in cluster.member_record_ids}
+        for root in roots.intersection(grouped):
+            grouped[root].update(cluster.member_record_ids)
+
+    for record_ids in grouped.values():
+        ordered_ids = tuple(sorted(record_ids))
+        candidates = [
+            candidate
+            for candidate in review_candidates
+            if candidate.left_record_id in record_ids
+            and candidate.right_record_id in record_ids
+        ]
+        cluster_evidence = [
+            note
+            for cluster in clusters
+            if set(cluster.member_record_ids).issubset(record_ids)
+            for note in cluster.evidence_notes
+        ]
+        reports.append(_report(
+            "review_required",
+            ordered_ids,
+            records_by_id,
+            [*cluster_evidence, *(note for candidate in candidates for note in candidate.evidence)],
+            (conflict for candidate in candidates for conflict in candidate.conflicts),
+        ))
+
+    return tuple(sorted(reports, key=lambda report: (report.status, report.record_ids, report.report_id)))
+
+
+def resolve_companies(records: Iterable[CompanyRecord], config: ResolverConfig | None = None) -> ResolutionResult:
+    config = config or ResolverConfig()
+    sorted_records = sorted(records, key=lambda record: record.record_id)
+    if len({record.record_id for record in sorted_records}) != len(sorted_records):
+        raise ValueError("record_id values must be unique")
+    records_by_id = {record.record_id: record for record in sorted_records}
+    weights = token_weights(sorted_records)
+    candidate_pairs = generate_candidate_pairs(sorted_records)
+    candidates: list[CompanyCandidate] = []
+    for left_id, right_id in candidate_pairs:
+        candidates.append(score_candidate(records_by_id[left_id], records_by_id[right_id], config, weights))
+
+    proposed_auto = sorted((candidate for candidate in candidates if candidate.tier == "auto_merge"), key=lambda c: (c.left_record_id, c.right_record_id))
+    review_candidates = [candidate for candidate in candidates if candidate.tier == "review"]
+    rejected_candidates = [candidate for candidate in candidates if candidate.tier == "reject"]
+    applied_auto: list[CompanyCandidate] = []
+
+    union_find = _UnionFind(records_by_id)
+    for candidate in proposed_auto:
+        left_root = union_find.find(candidate.left_record_id)
+        right_root = union_find.find(candidate.right_record_id)
+        left_regs = {
+            reg
+            for record_id, record in records_by_id.items()
+            if union_find.find(record_id) == left_root and (reg := record_registration(record))
+        }
+        right_regs = {
+            reg
+            for record_id, record in records_by_id.items()
+            if union_find.find(record_id) == right_root and (reg := record_registration(record))
+        }
+        if left_regs and right_regs and left_regs.isdisjoint(right_regs):
+            review_candidates.append(
+                replace(
+                    candidate,
+                    tier="review",
+                    conflicts=tuple(dict.fromkeys((*candidate.conflicts, "cluster_registration_conflict"))),
+                )
+            )
+            continue
+        union_find.union(candidate.left_record_id, candidate.right_record_id)
+        applied_auto.append(candidate)
+
+    auto_matches = tuple(applied_auto)
+    review_matches = tuple(sorted(review_candidates, key=lambda c: (c.left_record_id, c.right_record_id)))
+    rejected_matches = tuple(sorted(rejected_candidates, key=lambda c: (c.left_record_id, c.right_record_id)))
+
+    grouped: dict[str, list[CompanyRecord]] = defaultdict(list)
+    for record in sorted_records:
+        grouped[union_find.find(record.record_id)].append(record)
+
+    clusters: list[CompanyCluster] = []
+    for members in grouped.values():
+        if len(members) < 2:
+            continue
+        member_ids = tuple(sorted(record.record_id for record in members))
+        aliases = tuple(sorted({record.name for record in members}, key=lambda value: (value.lower(), value)))
+        member_pairs = [
+            candidate
+            for candidate in auto_matches
+            if candidate.left_record_id in member_ids and candidate.right_record_id in member_ids
+        ]
+        # Review candidates are intentionally excluded: only automatic pairs
+        # are allowed to create a cluster without human confirmation.
+        notes = tuple(sorted({note for candidate in member_pairs for note in candidate.evidence}))
+        clusters.append(
+            CompanyCluster(
+                cluster_id=_cluster_id(member_ids),
+                canonical_name=_canonical_name(members),
+                aliases=aliases,
+                member_record_ids=member_ids,
+                supporting_metadata=_supporting_metadata(members),
+                evidence_notes=notes,
+            )
+        )
+
+    clusters.sort(key=lambda cluster: (cluster.member_record_ids, cluster.cluster_id))
+    duplicate_name_reports = _duplicate_name_reports(
+        records_by_id,
+        clusters,
+        review_matches,
+    )
+    return ResolutionResult(
+        clusters=tuple(clusters),
+        auto_matches=auto_matches,
+        duplicate_name_reports=duplicate_name_reports,
+        review_candidates=review_matches,
+        rejected_candidates=rejected_matches,
+    )

--- a/src/entity_resolution/review.py
+++ b/src/entity_resolution/review.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Build auditable prompts for ambiguous pairs; this module makes no LLM call."""
+
+import json
+
+from .models import CompanyCandidate, CompanyRecord
+
+
+def generate_review_prompt(
+    left: CompanyRecord,
+    right: CompanyRecord,
+    candidate: CompanyCandidate,
+    max_snippets: int = 2,
+) -> str:
+    payload = {
+        "left": {
+            "record_id": left.record_id,
+            "name": left.name,
+            "metadata": left.metadata,
+            "snippets": left.snippets[:max_snippets],
+        },
+        "right": {
+            "record_id": right.record_id,
+            "name": right.name,
+            "metadata": right.metadata,
+            "snippets": right.snippets[:max_snippets],
+        },
+        "score": candidate.score,
+        "evidence": list(candidate.evidence),
+        "conflicts": list(candidate.conflicts),
+    }
+    return (
+        "Decide whether these company records refer to the same legal entity. "
+        "Beware parent/subsidiary/group ambiguity and related but distinct companies. "
+        "Return strict JSON with keys decision, confidence, and rationale. "
+        "decision must be one of same, different, uncertain.\n\n"
+        + json.dumps(payload, indent=2, sort_keys=True)
+    )

--- a/src/entity_resolution/scoring.py
+++ b/src/entity_resolution/scoring.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+"""Explainable pair scoring based on names, metadata, and explicit conflicts."""
+
+from difflib import SequenceMatcher
+
+from .models import CompanyCandidate, CompanyRecord, ResolverConfig
+from .metadata import record_address, record_domain, record_registration
+from .normalization import company_initials, normalize_company_name
+from .token_stats import WEAK_WORDS, weighted_token_overlap
+
+
+def _is_short_or_acronym(tokens: tuple[str, ...]) -> bool:
+    return len(tokens) <= 1 or any(len(token) <= 3 and token.isalpha() for token in tokens)
+
+
+def _token_overlap(left: tuple[str, ...], right: tuple[str, ...]) -> float:
+    left_set, right_set = set(left), set(right)
+    union = left_set | right_set
+    return len(left_set & right_set) / len(union) if union else 0.0
+
+
+def score_candidate(
+    left: CompanyRecord,
+    right: CompanyRecord,
+    config: ResolverConfig | None = None,
+    weights: dict[str, float] | None = None,
+) -> CompanyCandidate:
+    config = config or ResolverConfig()
+    weights = weights or {}
+    left_forms = normalize_company_name(left.name)
+    right_forms = normalize_company_name(right.name)
+    evidence: list[str] = []
+    conflicts: list[str] = []
+    score = 0.0
+
+    exact_core = bool(left_forms.core and left_forms.core == right_forms.core)
+    sorted_match = bool(left_forms.sorted_tokens and left_forms.sorted_tokens == right_forms.sorted_tokens)
+    if exact_core:
+        score = max(score, 0.96)
+        evidence.append("exact_core_name")
+    if sorted_match and not exact_core:
+        score = max(score, 0.9)
+        evidence.append("sorted_token_match")
+
+    fuzzy = SequenceMatcher(None, left_forms.core, right_forms.core).ratio() if left_forms.core and right_forms.core else 0.0
+    overlap = _token_overlap(left_forms.tokens, right_forms.tokens)
+    rarity_overlap = weighted_token_overlap(left_forms.tokens, right_forms.tokens, weights)
+    shared = set(left_forms.tokens) & set(right_forms.tokens)
+    distinctive_shared = sorted(token for token in shared if token not in WEAK_WORDS)
+    if distinctive_shared:
+        evidence.append("shared_distinctive_tokens:" + ",".join(distinctive_shared))
+    if overlap:
+        evidence.append(f"token_overlap:{overlap:.3f}")
+    if rarity_overlap:
+        evidence.append(f"rarity_weighted_overlap:{rarity_overlap:.3f}")
+    if fuzzy:
+        evidence.append(f"fuzzy_ratio:{fuzzy:.3f}")
+
+    score = max(score, (0.45 * fuzzy) + (0.45 * overlap))
+    if distinctive_shared:
+        score += min(0.18, 0.09 * len(distinctive_shared))
+    if distinctive_shared and any(token in WEAK_WORDS for token in set(left_forms.tokens) ^ set(right_forms.tokens)):
+        score += 0.08
+        evidence.append("related_industry_terms")
+    if shared and shared <= WEAK_WORDS:
+        score -= 0.25
+
+    left_domain = record_domain(left)
+    right_domain = record_domain(right)
+    if left_domain and right_domain:
+        if left_domain == right_domain:
+            score += 0.28
+            evidence.append("same_domain")
+        else:
+            conflicts.append("domain_conflict")
+            score -= 0.18
+
+    left_registration = record_registration(left)
+    right_registration = record_registration(right)
+    if left_registration and right_registration:
+        if left_registration == right_registration:
+            score += 0.35
+            evidence.append("same_registration_number")
+        else:
+            conflicts.append("registration_number_conflict")
+            score -= 0.45
+
+    left_address = record_address(left)
+    right_address = record_address(right)
+    if left_address and right_address and left_address == right_address:
+        score += 0.22
+        evidence.append("same_address")
+
+    same_domain = bool(left_domain and right_domain and left_domain == right_domain)
+    same_registration = bool(left_registration and right_registration and left_registration == right_registration)
+    same_address = bool(left_address and right_address and left_address == right_address)
+    left_initials = company_initials(left_forms.tokens)
+    right_initials = company_initials(right_forms.tokens)
+    acronym_match = bool(left_initials and left_initials == right_initials and left_forms.core != right_forms.core)
+    if acronym_match:
+        evidence.append("acronym_match")
+        score = max(score, config.review_threshold)
+    short_guard = _is_short_or_acronym(left_forms.tokens) or _is_short_or_acronym(right_forms.tokens)
+    score = max(0.0, min(1.0, score))
+
+    review_evidence = bool(exact_core or sorted_match or distinctive_shared or same_domain or same_address or acronym_match or score >= config.review_threshold)
+    if conflicts:
+        tier = "review" if review_evidence or same_registration else "reject"
+    elif same_registration:
+        tier = "auto_merge"
+    elif exact_core and score >= config.auto_merge_threshold:
+        tier = "auto_merge"
+    elif review_evidence:
+        tier = "review"
+    elif short_guard:
+        tier = "reject"
+    else:
+        tier = "reject"
+
+    return CompanyCandidate(
+        left_record_id=min(left.record_id, right.record_id),
+        right_record_id=max(left.record_id, right.record_id),
+        score=score,
+        tier=tier,
+        evidence=tuple(dict.fromkeys(evidence)),
+        conflicts=tuple(dict.fromkeys(conflicts)),
+    )

--- a/src/entity_resolution/token_stats.py
+++ b/src/entity_resolution/token_stats.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Lightweight corpus-level token rarity features; no external NLP required."""
+
+import math
+from collections import Counter
+from collections.abc import Iterable
+
+from .models import CompanyRecord
+from .normalization import normalize_company_name
+
+
+WEAK_WORDS = {
+    "capital",
+    "chemical",
+    "energy",
+    "global",
+    "group",
+    "holding",
+    "holdings",
+    "industry",
+    "industries",
+    "petrochemical",
+    "solution",
+    "technology",
+}
+
+
+def token_weights(records: Iterable[CompanyRecord]) -> dict[str, float]:
+    token_sets = [set(normalize_company_name(record.name).tokens) for record in records]
+    total = max(len(token_sets), 1)
+    document_frequency = Counter(token for tokens in token_sets for token in tokens)
+    weights: dict[str, float] = {}
+    for token, frequency in document_frequency.items():
+        weight = math.log((1 + total) / (1 + frequency)) + 1.0
+        if token in WEAK_WORDS:
+            weight *= 0.35
+        weights[token] = weight
+    return weights
+
+
+def weighted_token_overlap(left: Iterable[str], right: Iterable[str], weights: dict[str, float]) -> float:
+    left_set = set(left)
+    right_set = set(right)
+    if not left_set or not right_set:
+        return 0.0
+    union = left_set | right_set
+    shared = left_set & right_set
+    numerator = sum(weights.get(token, 1.0) for token in shared)
+    denominator = sum(weights.get(token, 1.0) for token in union)
+    return numerator / denominator if denominator else 0.0

--- a/src/providers/gemini.py
+++ b/src/providers/gemini.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import queue
+import math
+import re
 import threading
 import time
 
@@ -9,6 +11,39 @@ from google import genai
 from google.genai import types as genai_types
 
 from ..swarm.models import ModelCaller, ModelResult
+
+
+class _RequestLimiter:
+    def __init__(self, requests_per_minute: int):
+        if requests_per_minute <= 0:
+            raise ValueError("requests_per_minute must be positive")
+        self.interval = 60 / requests_per_minute
+        self.next_request = 0.0
+        self.lock = threading.Lock()
+
+    def wait(self) -> None:
+        with self.lock:
+            now = time.monotonic()
+            start = max(now, self.next_request)
+            self.next_request = start + self.interval
+
+        delay = start - now
+        if delay > 0:
+            time.sleep(delay)
+
+
+# Shared across callers and worker threads in this process.
+# ponytail: process-global lock; use a shared store only for multi-process runs.
+_GEMINI_LIMITER = _RequestLimiter(
+    int(os.environ.get("GEMINI_REQUESTS_PER_MINUTE", "10"))
+)
+
+
+def _retry_delay(error: Exception, attempt: int) -> int:
+    match = re.search(r"retry in\s+([0-9]+(?:\.[0-9]+)?)s", str(error), re.IGNORECASE)
+    if match:
+        return max(1, math.ceil(float(match.group(1))))
+    return min(60, 5 * (2 ** attempt))
 
 
 class GeminiCaller:
@@ -73,6 +108,7 @@ class GeminiCaller:
         for attempt in range(5):
             t0 = time.perf_counter()
             try:
+                _GEMINI_LIMITER.wait()
                 response = self._generate_content_with_timeout(prompt, config)
             except TimeoutError as e:
                 last_err = e
@@ -96,7 +132,7 @@ class GeminiCaller:
                         "timeout",
                     )
                 ):
-                    wait = min(60, 5 * (2 ** attempt))
+                    wait = _retry_delay(e, attempt)
                     time.sleep(wait)
                     last_err = e
                     continue

--- a/src/swarm/__init__.py
+++ b/src/swarm/__init__.py
@@ -24,6 +24,8 @@ from .derived_work import (
     calculation_debt_enabled,
     run_calculation_debt_detection,
 )
+from .entity_maintenance import maintenance_is_due, run_entity_maintenance
+from .entity_maintenance_store import EntityMaintenanceConfig
 from .obligations import build_synthesis_obligations
 from .models import (
     Document, DocumentStatus, Entry, EntrySource, ModelCaller, Task,
@@ -116,6 +118,7 @@ def run_swarm(task: Task, caller: ModelCaller, *,
     min_iter = min_iterations or int(os.getenv("SWARM_MIN_ITERATIONS", "2"))
     synth_caller = synthesis_caller or caller
     review_caller = reviewer_caller
+    entity_maintenance_config = EntityMaintenanceConfig.from_metadata(task.metadata)
 
     # Phase 1: Initialize
     blackboard = Blackboard(
@@ -357,6 +360,13 @@ def run_swarm(task: Task, caller: ModelCaller, *,
                     if ds.name == doc_name:
                         ds.mark_section_read(sec_name)
         blackboard.add_entries_batch(new_entries)
+        if maintenance_is_due(iteration, entity_maintenance_config):
+            run_entity_maintenance(
+                blackboard,
+                review_caller or caller,
+                entity_maintenance_config,
+                trigger="periodic",
+            )
         _entries_per_iter.append(len(new_entries))
 
         new_sigs = [
@@ -602,6 +612,12 @@ def run_swarm(task: Task, caller: ModelCaller, *,
 
     # Phase 8b: consolidate near-duplicate items, then build synthesis packet
     must_include = consolidate_items(must_include)
+    run_entity_maintenance(
+        blackboard,
+        review_caller or caller,
+        entity_maintenance_config,
+        trigger="final",
+    )
     synthesis_packet = build_synthesis_packet(must_include, blackboard)
     write_synthesis_packet_report(synthesis_packet, blackboard.output_dir)
 

--- a/src/swarm/__init__.py
+++ b/src/swarm/__init__.py
@@ -932,14 +932,13 @@ Return JSON: {{"findings": [...]}}"""
             payload, 0, f"reader_{rt['doc_name'][:20]}", "initial_reading",
             direct_document_context=True,
         )
-        # Backfill source on entries that lack it — we KNOW the doc and section
+        # Bind the known read context; only the model-supplied exact quote varies.
         for e in entries:
-            if not e.source or not e.source.document:
-                e.source = EntrySource(
-                    document=rt["doc_name"],
-                    section=rt["section_name"],
-                    evidence=e.source.evidence if e.source else "",
-                )
+            e.source = EntrySource(
+                document=rt["doc_name"],
+                section=rt["section_name"],
+                evidence=e.source.evidence if e.source else "",
+            )
         return entries, tokens, rt["doc_name"], rt["section_name"]
 
     max_w = min(len(read_tasks), 10)

--- a/src/swarm/__init__.py
+++ b/src/swarm/__init__.py
@@ -618,6 +618,29 @@ def run_swarm(task: Task, caller: ModelCaller, *,
         entity_maintenance_config,
         trigger="final",
     )
+
+    included_entry_ids = {
+        str(entry_id).strip()
+        for item in must_include if isinstance(item, dict)
+        for raw_ids in [item.get("entry_ids", item.get("entry_id", ""))]
+        for entry_id in (
+            raw_ids if isinstance(raw_ids, list) else str(raw_ids).split(",")
+        )
+        if str(entry_id).strip()
+    }
+    for entry in sorted(blackboard.entries, key=lambda item: item.id):
+        if (
+            entry.status == "active"
+            and entry.type == "duplicate_name_resolution"
+            and entry.id not in included_entry_ids
+        ):
+            must_include.append({
+                "entry_id": entry.id,
+                "summary": entry.content,
+                "section": "Entity resolution",
+                "importance": "critical",
+                "source": "entity_maintenance",
+            })
     synthesis_packet = build_synthesis_packet(must_include, blackboard)
     write_synthesis_packet_report(synthesis_packet, blackboard.output_dir)
 

--- a/src/swarm/__init__.py
+++ b/src/swarm/__init__.py
@@ -56,6 +56,7 @@ from .synthesis import (
 )
 from .survival_trace import write_pending_survival_trace
 from .worker_dispatch import (
+    ENTITY_ANNOTATION_INSTRUCTIONS,
     call_model, execute_workers_parallel, parse_worker_output,
     passes_quality_gate,
 )
@@ -907,10 +908,13 @@ For each finding:
 - confidence: 0.9 for directly quoted facts, 0.7 for inferences
 - epistemic_classification: fact | adversarial_claim | expert_opinion | strategic
 
+{ENTITY_ANNOTATION_INSTRUCTIONS}
+
 Return JSON: {{"findings": [...]}}"""
         payload, tokens = call_model(caller, prompt, max_tokens=8192)
         entries = parse_worker_output(
             payload, 0, f"reader_{rt['doc_name'][:20]}", "initial_reading",
+            direct_document_context=True,
         )
         # Backfill source on entries that lack it — we KNOW the doc and section
         for e in entries:

--- a/src/swarm/blackboard.py
+++ b/src/swarm/blackboard.py
@@ -5,6 +5,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .entity_maintenance_store import EntityMaintenanceState
 from .models import (
     DocumentStatus, Entry, Signal, WorkerRecord,
     gen_entry_id, gen_signal_id,
@@ -45,6 +46,13 @@ class Blackboard:
     token_budget: int = 3_000_000
     started_at: str = ""
     output_dir: str = ""
+    entity_maintenance_state: EntityMaintenanceState = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.entity_maintenance_state = (
+            EntityMaintenanceState.load(self.output_dir)
+            if self.output_dir else EntityMaintenanceState()
+        )
 
     def add_tokens_from_last_call(self, tokens: int) -> None:
         """Add tokens and grab model info from the last call_model invocation."""
@@ -262,5 +270,10 @@ class Blackboard:
             "iteration": self.iteration,
             "total_tokens_used": self.total_tokens_used,
             "token_budget": self.token_budget,
+            "entity_maintenance": {
+                "processed_cards": len(self.entity_maintenance_state.processed_card_fingerprints),
+                "profiles": len(self.entity_maintenance_state.profiles),
+                "decisions": len(self.entity_maintenance_state.decisions),
+            },
         }
         path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")

--- a/src/swarm/entity_annotations.py
+++ b/src/swarm/entity_annotations.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+ENTITY_TYPES = frozenset({"company", "person"})
+COMPANY_ATTRIBUTE_KINDS = frozenset({
+    "registration_number", "tax_id", "domain", "website", "email_domain",
+    "address", "alias",
+})
+PERSON_ATTRIBUTE_KINDS = frozenset({
+    "government_id", "birth_date", "email", "phone", "residence", "birthplace",
+    "workplace", "profession", "nationality", "gender", "family_member", "alias",
+})
+MAX_ENTITIES_PER_ENTRY = 20
+MAX_ATTRIBUTES_PER_ENTITY = 20
+VERIFIED_COMPANY_IDENTIFIER_KINDS = frozenset({"registration_number", "tax_id"})
+
+
+def _literally_supported(value: str, evidence: str) -> bool:
+    """Require the worker's exact source-local spelling in its evidence quote."""
+    stripped = value.strip()
+    return bool(stripped and stripped in evidence)
+
+
+@dataclass(frozen=True)
+class EntityAnnotationValidation:
+    annotations: list[dict[str, Any]]
+    rejections: Sequence[str]
+
+
+def validate_entity_annotation_result(
+    value: object,
+    evidence: str,
+    *,
+    require_literal_evidence: bool = True,
+) -> EntityAnnotationValidation:
+    if not isinstance(value, list):
+        return EntityAnnotationValidation([], ("entities_not_a_list",))
+
+    validated: list[dict[str, Any]] = []
+    rejections: list[str] = []
+    for raw_entity in value[:MAX_ENTITIES_PER_ENTRY]:
+        if not isinstance(raw_entity, dict):
+            rejections.append("entity_not_object")
+            continue
+
+        entity_type = raw_entity.get("entity_type")
+        name = raw_entity.get("name")
+        if entity_type not in ENTITY_TYPES or not isinstance(name, str) or not name.strip():
+            rejections.append("invalid_entity_shape")
+            continue
+        name = name.strip()
+        if require_literal_evidence and not _literally_supported(name, evidence):
+            rejections.append("entity_name_not_in_evidence")
+            continue
+
+        allowed_kinds = (
+            COMPANY_ATTRIBUTE_KINDS if entity_type == "company" else PERSON_ATTRIBUTE_KINDS
+        )
+        attributes: list[dict[str, Any]] = []
+        raw_attributes = raw_entity.get("attributes", [])
+        if not isinstance(raw_attributes, list):
+            rejections.append("attributes_not_a_list")
+            raw_attributes = []
+        for raw_attribute in raw_attributes[:MAX_ATTRIBUTES_PER_ENTITY]:
+            if not isinstance(raw_attribute, dict):
+                rejections.append("attribute_not_object")
+                continue
+            kind, attribute_value = raw_attribute.get("kind"), raw_attribute.get("value")
+            if kind not in allowed_kinds or not isinstance(attribute_value, str) or not attribute_value.strip():
+                rejections.append("invalid_attribute_shape")
+                continue
+            attribute_value = attribute_value.strip()
+            if require_literal_evidence and not _literally_supported(attribute_value, evidence):
+                rejections.append("attribute_value_not_in_evidence")
+                continue
+            raw_qualifiers = raw_attribute.get("qualifiers", {})
+            qualifiers = {
+                key.strip(): item.strip()
+                for key, item in raw_qualifiers.items()
+                if isinstance(key, str) and key.strip() and isinstance(item, str) and item.strip()
+            } if isinstance(raw_qualifiers, dict) else {}
+            requested_verified = raw_attribute.get("verified") is True
+            verification_allowed = (
+                entity_type == "company" and kind in VERIFIED_COMPANY_IDENTIFIER_KINDS
+            ) or (
+                entity_type == "person" and kind in {"government_id", "birth_date"}
+            )
+            if kind == "government_id":
+                verification_allowed = verification_allowed and bool(
+                    qualifiers.get("issuer") and qualifiers.get("identifier_type")
+                )
+            attributes.append({
+                "kind": kind,
+                "value": attribute_value,
+                "verified": requested_verified and verification_allowed,
+                "qualifiers": dict(sorted(qualifiers.items())),
+            })
+        validated.append({
+            "entity_type": entity_type,
+            "name": name,
+            "attributes": attributes,
+        })
+    return EntityAnnotationValidation(validated, tuple(sorted(set(rejections))))
+
+
+def validate_entity_annotations(value: object, evidence: str) -> list[dict[str, Any]]:
+    """Keep only source-local entity annotations supported by this entry's evidence."""
+    return validate_entity_annotation_result(value, evidence).annotations

--- a/src/swarm/entity_candidate_scoring.py
+++ b/src/swarm/entity_candidate_scoring.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+"""Persist conservative duplicate candidates for changed entity profiles."""
+
+from collections import defaultdict
+from collections.abc import Collection, Iterable, Mapping
+from dataclasses import dataclass
+import hashlib
+import json
+from itertools import combinations
+
+from src.entity_resolution import (
+    CompanyRecord,
+    PersonAttribute,
+    PersonRecord,
+    resolve_companies,
+    resolve_people,
+)
+from src.entity_resolution.person_normalization import government_id_components
+
+from .entity_maintenance_store import EntityMaintenanceConfig, EntityMaintenanceState
+
+
+@dataclass(frozen=True)
+class CandidateRefreshSummary:
+    new_candidate_ids: tuple[str, ...] = ()
+    changed_candidate_ids: tuple[str, ...] = ()
+    reused_candidate_ids: tuple[str, ...] = ()
+    review_candidate_ids: tuple[str, ...] = ()
+
+
+def refresh_candidates(
+    state: EntityMaintenanceState,
+    dirty_profile_ids: Collection[str],
+    config: EntityMaintenanceConfig,
+) -> CandidateRefreshSummary:
+    """Score dirty profile neighbours without changing profile membership."""
+    dirty = set(dirty_profile_ids)
+    profiles = {
+        profile_id: profile
+        for profile_id, profile in state.profiles.items()
+        if isinstance(profile, Mapping) and profile.get("entity_type") in {"company", "person"}
+    }
+    candidates = [
+        *(_company_candidates(profiles, dirty, config)),
+        *(_person_candidates(profiles, dirty, config)),
+        *(_intra_profile_candidates(profiles, dirty)),
+    ]
+    new: list[str] = []
+    changed: list[str] = []
+    reused: list[str] = []
+    review: list[str] = []
+    for candidate in sorted(candidates, key=lambda item: str(item["semantic_key"])):
+        matching_id = _matching_candidate_id(state.candidates, candidate)
+        if matching_id is not None:
+            reused.append(matching_id)
+            continue
+        candidate_id = str(candidate["candidate_id"])
+        existing = state.candidates.get(candidate_id)
+        if existing is None:
+            new.append(candidate_id)
+        else:
+            changed.append(candidate_id)
+        state.candidates[candidate_id] = candidate
+        if candidate["status"] == "pending_review":
+            review.append(candidate_id)
+    return CandidateRefreshSummary(
+        tuple(sorted(new)),
+        tuple(sorted(changed)),
+        tuple(sorted(reused)),
+        tuple(sorted(review)),
+    )
+
+
+def _company_candidates(
+    profiles: Mapping[str, Mapping[str, object]],
+    dirty: set[str],
+    config: EntityMaintenanceConfig,
+) -> Iterable[dict[str, object]]:
+    company_profiles = {
+        profile_id: profile
+        for profile_id, profile in profiles.items()
+        if profile.get("entity_type") == "company"
+    }
+    records: list[CompanyRecord] = []
+    record_profiles: dict[str, str] = {}
+    for profile_id, profile in sorted(company_profiles.items()):
+        metadata = _company_metadata(profile)
+        for index, name in enumerate(_profile_names(profile)):
+            record_id = f"{profile_id}#{index}"
+            records.append(CompanyRecord(record_id, name, metadata=metadata))
+            record_profiles[record_id] = profile_id
+
+    by_pair: dict[tuple[str, str], list[object]] = defaultdict(list)
+    result = resolve_companies(records)
+    for resolver_candidate in (
+        *result.auto_matches,
+        *result.review_candidates,
+        *result.rejected_candidates,
+    ):
+        profile_ids = tuple(sorted({
+            record_profiles[resolver_candidate.left_record_id],
+            record_profiles[resolver_candidate.right_record_id],
+        }))
+        if len(profile_ids) == 2 and dirty.intersection(profile_ids):
+            by_pair[profile_ids].append(resolver_candidate)
+
+    for profile_ids, resolver_candidates in sorted(by_pair.items()):
+        winner = max(resolver_candidates, key=lambda item: item.score)
+        evidence = sorted({note for item in resolver_candidates for note in item.evidence})
+        conflicts = set(note for item in resolver_candidates for note in item.conflicts)
+        conflicts.update(_company_verified_conflicts(
+            company_profiles[profile_ids[0]], company_profiles[profile_ids[1]],
+        ))
+        yield _candidate(
+            "company", profile_ids, company_profiles, winner.score, evidence, sorted(conflicts), config,
+        )
+
+
+def _person_candidates(
+    profiles: Mapping[str, Mapping[str, object]],
+    dirty: set[str],
+    config: EntityMaintenanceConfig,
+) -> Iterable[dict[str, object]]:
+    person_profiles = {
+        profile_id: profile
+        for profile_id, profile in profiles.items()
+        if profile.get("entity_type") == "person"
+    }
+    records = [_person_record(profile_id, profile) for profile_id, profile in sorted(person_profiles.items())]
+    result = resolve_people(records)
+    candidate_data: dict[tuple[str, str], tuple[float, set[str], set[str]]] = {}
+
+    def add(profile_ids: tuple[str, str], score: float, evidence: Iterable[str], conflicts: Iterable[str]) -> None:
+        if not dirty.intersection(profile_ids):
+            return
+        current = candidate_data.get(profile_ids)
+        if current is None:
+            candidate_data[profile_ids] = (score, set(evidence), set(conflicts))
+            return
+        candidate_data[profile_ids] = (
+            max(score, current[0]), current[1] | set(evidence), current[2] | set(conflicts),
+        )
+
+    for match in result.auto_matches:
+        add(tuple(sorted((match.left_record_id, match.right_record_id))), 1.0, ("same_verified_government_id",), ())
+    for connection in result.uncertain_connections:
+        member_ids = sorted({
+            *connection.left.member_record_ids,
+            *connection.right.member_record_ids,
+        })
+        evidence = (item.kind + ":" + item.relationship for item in connection.evidence)
+        for profile_ids in combinations(member_ids, 2):
+            add(profile_ids, connection.score, evidence, connection.conflicts)
+
+    for profile_ids, (score, evidence, conflicts) in sorted(candidate_data.items()):
+        augmented_conflicts = conflicts | set(_person_verified_conflicts(
+            person_profiles[profile_ids[0]], person_profiles[profile_ids[1]],
+        ))
+        yield _candidate(
+            "person", profile_ids, person_profiles, score, sorted(evidence), sorted(augmented_conflicts), config,
+        )
+
+
+def _intra_profile_candidates(
+    profiles: Mapping[str, Mapping[str, object]], dirty: set[str],
+) -> Iterable[dict[str, object]]:
+    for profile_id, profile in sorted(profiles.items()):
+        if profile_id not in dirty:
+            continue
+        conflicts, source_card_groups = _intra_profile_conflicts(profile)
+        if not conflicts:
+            continue
+        yield _candidate(
+            str(profile["entity_type"]), (profile_id,), profiles, 0.0, (), conflicts, None,
+            source_card_groups=source_card_groups,
+        )
+
+
+def _candidate(
+    entity_type: str,
+    profile_ids: tuple[str, ...],
+    profiles: Mapping[str, Mapping[str, object]],
+    score: float,
+    evidence: Iterable[str],
+    conflicts: Iterable[str],
+    config: EntityMaintenanceConfig | None,
+    *,
+    source_card_groups: list[list[str]] | None = None,
+) -> dict[str, object]:
+    evidence = sorted(set(evidence))
+    conflicts = sorted(set(conflicts))
+    score = round(max(0.0, min(1.0, score)), 6)
+    semantic_key = entity_type + ":" + "|".join(profile_ids)
+    hard_conflict = bool(set(conflicts) & {
+        "verified_registration_number_conflict",
+        "verified_tax_id_conflict",
+        "verified_birth_date_conflict",
+        "competing_verified_government_ids",
+    })
+    status = "pending_review" if hard_conflict or (
+        config is not None
+        and score >= config.duplicate_review_threshold
+        and _independent_evidence_count(evidence) >= 2
+    ) else "ignored"
+    fingerprint_payload = {
+        "profile_ids": profile_ids,
+        "profiles": [
+            (profile_id, profiles[profile_id].get("revision"), profiles[profile_id].get("fingerprint"))
+            for profile_id in profile_ids
+        ],
+        "score": score,
+        "evidence": evidence,
+        "conflicts": conflicts,
+    }
+    evidence_fingerprint = "candidate_fp_" + _digest(fingerprint_payload)
+    return {
+        "candidate_id": "candidate_" + _digest(semantic_key),
+        "semantic_key": semantic_key,
+        "evidence_fingerprint": evidence_fingerprint,
+        "profile_ids": list(profile_ids),
+        "source_card_groups": source_card_groups or [
+            sorted(_source_card_ids(profiles[profile_id])) for profile_id in profile_ids
+        ],
+        "entity_type": entity_type,
+        "score": score,
+        "evidence": evidence,
+        "conflicts": conflicts,
+        "status": status,
+    }
+
+
+def _company_metadata(profile: Mapping[str, object]) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for field in ("registration_number", "tax_id", "domain", "website", "email_domain", "address"):
+        values = _fact_values(profile, {field})
+        if values:
+            metadata[field] = values[0]
+    return metadata
+
+
+def _person_record(profile_id: str, profile: Mapping[str, object]) -> PersonRecord:
+    attributes: list[PersonAttribute] = []
+    for fact in _facts(profile):
+        field, value = fact.get("field"), fact.get("value")
+        if not isinstance(field, str) or not isinstance(value, str) or field == "name":
+            continue
+        qualifiers = fact.get("qualifiers", {})
+        attributes.append(PersonAttribute(
+            kind=field,
+            value=value,
+            source_document_id=_string(fact.get("source_card_id")),
+            verified=_verified(fact),
+            qualifiers=tuple(sorted(qualifiers.items())) if isinstance(qualifiers, Mapping) else (),
+        ))
+    return PersonRecord(
+        profile_id,
+        _profile_names(profile)[0],
+        attributes=tuple(attributes),
+    )
+
+
+def _profile_names(profile: Mapping[str, object]) -> list[str]:
+    names = [profile.get("primary_name"), *(profile.get("aliases", []) if isinstance(profile.get("aliases"), list) else [])]
+    return sorted({name.strip() for name in names if isinstance(name, str) and name.strip()}, key=lambda name: (name.casefold(), name))
+
+
+def _facts(profile: Mapping[str, object]) -> Iterable[Mapping[str, object]]:
+    facts = profile.get("facts", [])
+    return (fact for fact in facts if isinstance(fact, Mapping)) if isinstance(facts, list) else ()
+
+
+def _fact_values(profile: Mapping[str, object], fields: set[str], *, verified: bool = False) -> list[str]:
+    return sorted({
+        value
+        for fact in _facts(profile)
+        if fact.get("field") in fields
+        and (not verified or _verified(fact))
+        and isinstance(value := fact.get("normalized_value"), str)
+        and value
+    })
+
+
+def _company_verified_conflicts(left: Mapping[str, object], right: Mapping[str, object]) -> tuple[str, ...]:
+    conflicts = []
+    for field, label in (
+        ("registration_number", "verified_registration_number_conflict"),
+        ("tax_id", "verified_tax_id_conflict"),
+    ):
+        left_values = set(_fact_values(left, {field}, verified=True))
+        right_values = set(_fact_values(right, {field}, verified=True))
+        if left_values and right_values and left_values.isdisjoint(right_values):
+            conflicts.append(label)
+    return tuple(conflicts)
+
+
+def _person_verified_conflicts(left: Mapping[str, object], right: Mapping[str, object]) -> tuple[str, ...]:
+    conflicts = []
+    left_birth_dates = set(_fact_values(left, {"birth_date"}, verified=True))
+    right_birth_dates = set(_fact_values(right, {"birth_date"}, verified=True))
+    if left_birth_dates and right_birth_dates and left_birth_dates.isdisjoint(right_birth_dates):
+        conflicts.append("verified_birth_date_conflict")
+    if _government_id_values_by_scheme(left) and _government_id_values_by_scheme(right):
+        for scheme in set(_government_id_values_by_scheme(left)) & set(_government_id_values_by_scheme(right)):
+            if _government_id_values_by_scheme(left)[scheme].isdisjoint(_government_id_values_by_scheme(right)[scheme]):
+                conflicts.append("competing_verified_government_ids")
+                break
+    return tuple(conflicts)
+
+
+def _intra_profile_conflicts(profile: Mapping[str, object]) -> tuple[list[str], list[list[str]]]:
+    fields = ("registration_number", "tax_id") if profile.get("entity_type") == "company" else ("birth_date",)
+    groups: list[list[str]] = []
+    conflicts: list[str] = []
+    for field in fields:
+        values = _verified_fact_cards(profile, field)
+        if len(values) > 1:
+            conflicts.append({
+                "registration_number": "verified_registration_number_conflict",
+                "tax_id": "verified_tax_id_conflict",
+                "birth_date": "verified_birth_date_conflict",
+            }[field])
+            groups.extend(cards for _, cards in sorted(values.items()))
+    if profile.get("entity_type") == "person":
+        by_scheme: dict[tuple[str, str], dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+        for fact in _facts(profile):
+            if fact.get("field") != "government_id" or not _verified(fact):
+                continue
+            attribute = PersonAttribute(
+                "government_id", str(fact.get("value", "")),
+                qualifiers=tuple(sorted(fact.get("qualifiers", {}).items())) if isinstance(fact.get("qualifiers"), Mapping) else (),
+                verified=True,
+            )
+            if components := government_id_components(attribute):
+                by_scheme[components[:2]][components[2]].add(_string(fact.get("source_card_id")) or "")
+        if any(len(values) > 1 for values in by_scheme.values()):
+            conflicts.append("competing_verified_government_ids")
+            groups.extend(
+                sorted(cards) for values in by_scheme.values() if len(values) > 1 for cards in values.values()
+            )
+    return sorted(set(conflicts)), [list(group) for group in sorted({tuple(group) for group in groups})]
+
+
+def _verified_fact_cards(profile: Mapping[str, object], field: str) -> dict[str, set[str]]:
+    values: dict[str, set[str]] = defaultdict(set)
+    for fact in _facts(profile):
+        value = fact.get("normalized_value")
+        if fact.get("field") == field and _verified(fact) and isinstance(value, str) and value:
+            card_id = _string(fact.get("source_card_id"))
+            if card_id:
+                values[value].add(card_id)
+    return values
+
+
+def _government_id_values_by_scheme(profile: Mapping[str, object]) -> dict[tuple[str, str], set[str]]:
+    by_scheme: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for fact in _facts(profile):
+        if fact.get("field") != "government_id" or not _verified(fact):
+            continue
+        qualifiers = fact.get("qualifiers", {})
+        attribute = PersonAttribute(
+            "government_id", str(fact.get("value", "")),
+            qualifiers=tuple(sorted(qualifiers.items())) if isinstance(qualifiers, Mapping) else (),
+            verified=True,
+        )
+        if components := government_id_components(attribute):
+            by_scheme[components[:2]].add(components[2])
+    return by_scheme
+
+
+def _independent_evidence_count(evidence: Iterable[str]) -> int:
+    categories = set()
+    for item in evidence:
+        if item.startswith(("exact_", "sorted_", "shared_", "token_", "rarity_", "fuzzy_", "acronym_", "related_", "name:")):
+            categories.add("name")
+        elif item.startswith("same_"):
+            categories.add(item)
+        elif ":" in item:
+            categories.add(item.split(":", 1)[0])
+    return len(categories)
+
+
+def _source_card_ids(profile: Mapping[str, object]) -> list[str]:
+    source_card_ids = profile.get("source_card_ids", [])
+    return [card_id for card_id in source_card_ids if isinstance(card_id, str)] if isinstance(source_card_ids, list) else []
+
+
+def _matching_candidate_id(
+    candidates: Mapping[str, Mapping[str, object]], candidate: Mapping[str, object],
+) -> str | None:
+    for candidate_id, existing in candidates.items():
+        if (
+            existing.get("semantic_key") == candidate["semantic_key"]
+            and existing.get("evidence_fingerprint") == candidate["evidence_fingerprint"]
+        ):
+            return candidate_id
+    return None
+
+
+def _verified(fact: Mapping[str, object]) -> bool:
+    return fact.get("verified") is True or fact.get("status") == "verified"
+
+
+def _string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _digest(value: object) -> str:
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]

--- a/src/swarm/entity_candidate_scoring.py
+++ b/src/swarm/entity_candidate_scoring.py
@@ -152,6 +152,14 @@ def _person_candidates(
         evidence = (item.kind + ":" + item.relationship for item in connection.evidence)
         for profile_ids in combinations(member_ids, 2):
             add(profile_ids, connection.score, evidence, connection.conflicts)
+    resolver_profiles = _resolver_person_profiles(records, result.auto_matches)
+    for left_resolver_id, right_resolver_id in result.screened_out_profile_pairs:
+        left_members = resolver_profiles.get(left_resolver_id, ())
+        right_members = resolver_profiles.get(right_resolver_id, ())
+        for left_profile_id in left_members:
+            for right_profile_id in right_members:
+                if left_profile_id != right_profile_id:
+                    add(tuple(sorted((left_profile_id, right_profile_id))), 0.0, (), ())
 
     for profile_ids, (score, evidence, conflicts) in sorted(candidate_data.items()):
         augmented_conflicts = conflicts | set(_person_verified_conflicts(
@@ -175,6 +183,34 @@ def _intra_profile_candidates(
             str(profile["entity_type"]), (profile_id,), profiles, 0.0, (), conflicts, None,
             source_card_groups=source_card_groups,
         )
+
+
+def _resolver_person_profiles(
+    records: Iterable[PersonRecord], auto_matches: Iterable[object],
+) -> dict[str, tuple[str, ...]]:
+    parent = {record.record_id: record.record_id for record in records}
+
+    def find(record_id: str) -> str:
+        if parent[record_id] != record_id:
+            parent[record_id] = find(parent[record_id])
+        return parent[record_id]
+
+    for match in auto_matches:
+        left_root, right_root = find(match.left_record_id), find(match.right_record_id)
+        if left_root != right_root:
+            parent[max(left_root, right_root)] = min(left_root, right_root)
+    groups: dict[str, list[str]] = defaultdict(list)
+    for record_id in parent:
+        groups[find(record_id)].append(record_id)
+    return {
+        _resolver_person_profile_id(member_ids): tuple(sorted(member_ids))
+        for member_ids in groups.values()
+    }
+
+
+def _resolver_person_profile_id(member_ids: Iterable[str]) -> str:
+    canonical = json.dumps(sorted(member_ids), ensure_ascii=False, separators=(",", ":"))
+    return "person_profile_" + hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:12]
 
 
 def _candidate(

--- a/src/swarm/entity_candidate_scoring.py
+++ b/src/swarm/entity_candidate_scoring.py
@@ -56,6 +56,11 @@ def refresh_candidates(
             reused.append(matching_id)
             continue
         candidate_id = str(candidate["candidate_id"])
+        if _has_confirmed_decision_with_same_conflicts(state, candidate):
+            candidate["status"] = "reviewed"
+            state.candidates[candidate_id] = candidate
+            reused.append(candidate_id)
+            continue
         existing = state.candidates.get(candidate_id)
         if existing is None:
             new.append(candidate_id)
@@ -234,10 +239,19 @@ def _candidate(
         "verified_birth_date_conflict",
         "competing_verified_government_ids",
     })
-    status = "pending_review" if hard_conflict or (
+    linked_hard_conflict = hard_conflict and (len(profile_ids) == 1 or score > 0)
+    person_name_candidate = (
+        entity_type == "person"
+        and score >= 0.30
+        and any(item.startswith("name:") for item in evidence)
+    )
+    threshold_candidate = (
         config is not None
         and score >= config.duplicate_review_threshold
         and _independent_evidence_count(evidence) >= 2
+    )
+    status = "pending_review" if (
+        linked_hard_conflict or person_name_candidate or threshold_candidate
     ) else "ignored"
     fingerprint_payload = {
         "profile_ids": profile_ids,
@@ -431,6 +445,19 @@ def _matching_candidate_id(
         ):
             return candidate_id
     return None
+
+
+def _has_confirmed_decision_with_same_conflicts(
+    state: EntityMaintenanceState, candidate: Mapping[str, object],
+) -> bool:
+    conflicts = sorted(candidate.get("conflicts", []))
+    return any(
+        decision.get("semantic_key") == candidate["semantic_key"]
+        and decision.get("outcome") in {"same_entity", "same_name_distinct_entity"}
+        and sorted(decision.get("conflicts", [])) == conflicts
+        for decision in state.decisions.values()
+        if isinstance(decision, Mapping)
+    )
 
 
 def _verified(fact: Mapping[str, object]) -> bool:

--- a/src/swarm/entity_maintenance.py
+++ b/src/swarm/entity_maintenance.py
@@ -6,10 +6,10 @@ from dataclasses import asdict, dataclass
 from typing import Literal
 
 from .blackboard import Blackboard
-from .entity_candidate_scoring import CandidateRefreshSummary, refresh_candidates
+from .entity_candidate_scoring import refresh_candidates
 from .entity_maintenance_store import EntityMaintenanceConfig, EntityMaintenanceState
 from .entity_mention_repair import RepairSummary, build_entity_catalogue, eligible_direct_entries, repair_entity_mentions
-from .entity_profiles import ProfileRefreshSummary, project_entity_information_cards, refresh_entity_profiles
+from .entity_profiles import project_entity_information_cards, refresh_entity_profiles
 from .entity_specialist_review import CONFIRMED_OUTCOMES, review_pending_candidates
 from .models import Entry, ModelCaller, WorkerRecord
 
@@ -49,8 +49,8 @@ def run_entity_maintenance(
     dirty_entries = [
         entry for entry in eligible_direct_entries(blackboard.entries) if state.card_is_dirty(entry)
     ]
+    all_direct_entries = eligible_direct_entries(blackboard.entries)
     if dirty_entries:
-        all_direct_entries = eligible_direct_entries(blackboard.entries)
         catalogue = build_entity_catalogue(all_direct_entries, state.profiles)
         repair = repair_entity_mentions(
             dirty_entries,
@@ -58,16 +58,16 @@ def run_entity_maintenance(
             config.entity_repair_max_mentions_per_card,
             f"entity-maintenance-{blackboard.iteration}-{trigger}",
         )
-        profiles = refresh_entity_profiles(
-            state, all_direct_entries, config.entity_profile_min_card_count,
-        )
-        project_entity_information_cards(blackboard, state, profiles)
-        candidates = refresh_candidates(state, set(profiles.dirty_profile_ids), config)
-        state.mark_cards_processed(dirty_entries)
     else:
         repair = RepairSummary()
-        profiles = ProfileRefreshSummary()
-        candidates = CandidateRefreshSummary()
+    profiles = refresh_entity_profiles(
+        state, all_direct_entries, config.entity_profile_min_card_count,
+    )
+    project_entity_information_cards(blackboard, state, profiles)
+    _retire_profile_dependencies(blackboard, state, profiles.retired_profile_ids)
+    candidates = refresh_candidates(state, set(profiles.dirty_profile_ids), config)
+    if dirty_entries:
+        state.mark_cards_processed(dirty_entries)
     review_ids = tuple(sorted(set(candidates.review_candidate_ids) | {
         candidate_id
         for candidate_id, candidate in state.candidates.items()
@@ -155,3 +155,26 @@ def _fingerprint(entry: Entry) -> str | None:
 
 def _strings(value: object) -> list[str]:
     return sorted({item for item in value if isinstance(item, str)}) if isinstance(value, list) else []
+
+
+def _retire_profile_dependencies(
+    blackboard: Blackboard,
+    state: EntityMaintenanceState,
+    retired_profile_ids: tuple[str, ...],
+) -> None:
+    retired = set(retired_profile_ids)
+    if not retired:
+        return
+    for records in (state.candidates, state.decisions):
+        for record_id, record in list(records.items()):
+            if isinstance(record, Mapping) and retired.intersection(_strings(record.get("profile_ids"))):
+                del records[record_id]
+    for entry in blackboard.entries:
+        if entry.type != "duplicate_name_resolution":
+            continue
+        try:
+            payload = json.loads(entry.content)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, Mapping) and retired.intersection(_strings(payload.get("profile_ids"))):
+            entry.status = "superseded"

--- a/src/swarm/entity_maintenance.py
+++ b/src/swarm/entity_maintenance.py
@@ -9,7 +9,7 @@ from .blackboard import Blackboard
 from .entity_candidate_scoring import refresh_candidates
 from .entity_maintenance_store import EntityMaintenanceConfig, EntityMaintenanceState
 from .entity_mention_repair import RepairSummary, build_entity_catalogue, eligible_direct_entries, repair_entity_mentions
-from .entity_profiles import project_entity_information_cards, refresh_entity_profiles
+from .entity_profiles import refresh_entity_profiles
 from .entity_specialist_review import CONFIRMED_OUTCOMES, review_pending_candidates
 from .models import Entry, ModelCaller, WorkerRecord
 
@@ -63,7 +63,6 @@ def run_entity_maintenance(
     profiles = refresh_entity_profiles(
         state, all_direct_entries, config.entity_profile_min_card_count,
     )
-    project_entity_information_cards(blackboard, state, profiles)
     _retire_profile_dependencies(blackboard, state, profiles.retired_profile_ids)
     candidates = refresh_candidates(state, set(profiles.dirty_profile_ids), config)
     if dirty_entries:

--- a/src/swarm/entity_maintenance.py
+++ b/src/swarm/entity_maintenance.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+from .blackboard import Blackboard
+from .entity_candidate_scoring import CandidateRefreshSummary, refresh_candidates
+from .entity_maintenance_store import EntityMaintenanceConfig, EntityMaintenanceState
+from .entity_mention_repair import RepairSummary, build_entity_catalogue, eligible_direct_entries, repair_entity_mentions
+from .entity_profiles import ProfileRefreshSummary, project_entity_information_cards, refresh_entity_profiles
+from .entity_specialist_review import CONFIRMED_OUTCOMES, review_pending_candidates
+from .models import Entry, ModelCaller, WorkerRecord
+
+
+@dataclass(frozen=True)
+class EntityMaintenanceRunSummary:
+    trigger: Literal["periodic", "final"]
+    processed_card_ids: tuple[str, ...] = ()
+    repaired_mentions: int = 0
+    dirty_profile_ids: tuple[str, ...] = ()
+    review_candidate_ids: tuple[str, ...] = ()
+    specialist_calls: int = 0
+    projected_decision_ids: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def maintenance_is_due(
+    iteration: int,
+    config: EntityMaintenanceConfig,
+    *,
+    final: bool = False,
+) -> bool:
+    interval = config.entity_resolution_interval_iterations
+    return final or (interval > 0 and iteration > 0 and iteration % interval == 0)
+
+
+def run_entity_maintenance(
+    blackboard: Blackboard,
+    caller: ModelCaller,
+    config: EntityMaintenanceConfig,
+    *,
+    trigger: Literal["periodic", "final"],
+) -> EntityMaintenanceRunSummary:
+    state = blackboard.entity_maintenance_state
+    dirty_entries = [
+        entry for entry in eligible_direct_entries(blackboard.entries) if state.card_is_dirty(entry)
+    ]
+    if dirty_entries:
+        all_direct_entries = eligible_direct_entries(blackboard.entries)
+        catalogue = build_entity_catalogue(all_direct_entries, state.profiles)
+        repair = repair_entity_mentions(
+            dirty_entries,
+            catalogue,
+            config.entity_repair_max_mentions_per_card,
+            f"entity-maintenance-{blackboard.iteration}-{trigger}",
+        )
+        profiles = refresh_entity_profiles(
+            state, all_direct_entries, config.entity_profile_min_card_count,
+        )
+        project_entity_information_cards(blackboard, state, profiles)
+        candidates = refresh_candidates(state, set(profiles.dirty_profile_ids), config)
+        state.mark_cards_processed(dirty_entries)
+    else:
+        repair = RepairSummary()
+        profiles = ProfileRefreshSummary()
+        candidates = CandidateRefreshSummary()
+    review_ids = tuple(sorted(set(candidates.review_candidate_ids) | {
+        candidate_id
+        for candidate_id, candidate in state.candidates.items()
+        if isinstance(candidate, Mapping) and candidate.get("status") == "review_retry"
+    }))
+    reviews = review_pending_candidates(state, review_ids, caller)
+    projected = project_confirmed_decisions(blackboard, state)
+    summary = EntityMaintenanceRunSummary(
+        trigger=trigger,
+        processed_card_ids=tuple(entry.id for entry in dirty_entries),
+        repaired_mentions=repair.repaired_mentions,
+        dirty_profile_ids=profiles.dirty_profile_ids,
+        review_candidate_ids=review_ids,
+        specialist_calls=reviews.model_calls,
+        projected_decision_ids=projected,
+    )
+    state.runs.append(summary.to_dict())
+    if blackboard.output_dir:
+        state.write(blackboard.output_dir)
+    return summary
+
+
+def project_confirmed_decisions(
+    blackboard: Blackboard,
+    state: EntityMaintenanceState,
+) -> tuple[str, ...]:
+    """Expose only confirmed sidecar decisions as stable resolution cards."""
+    projected: list[str] = []
+    for decision_id, decision in sorted(state.decisions.items()):
+        if not isinstance(decision, Mapping) or decision.get("outcome") not in CONFIRMED_OUTCOMES:
+            continue
+        semantic_key = decision.get("semantic_key")
+        fingerprint = decision.get("evidence_fingerprint")
+        if not isinstance(semantic_key, str) or not semantic_key or not isinstance(fingerprint, str):
+            continue
+        card_id = f"duplicate-resolution-{semantic_key}"
+        payload = {
+            "outcome": decision["outcome"],
+            "profile_ids": _strings(decision.get("profile_ids")),
+            "decision_id": str(decision.get("decision_id", decision_id)),
+            "evidence_fingerprint": fingerprint,
+            "source_card_ids": _strings(decision.get("source_card_ids")),
+            "rationale": str(decision.get("rationale", "")),
+            "conflicts": _strings(decision.get("conflicts")),
+        }
+        existing = blackboard.find_entry(card_id)
+        if existing is not None and _fingerprint(existing) == fingerprint:
+            continue
+        content = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        if existing is None:
+            blackboard.add_entry(_resolution_entry(blackboard, card_id, content))
+        else:
+            existing.type = "duplicate_name_resolution"
+            existing.content = content
+            existing.source = None
+            existing.created_by = WorkerRecord(
+                "entity_maintenance", "duplicate_name_resolution", blackboard.iteration,
+            )
+            existing.confidence = 1.0
+            existing.status = "active"
+        projected.append(decision_id)
+    return tuple(projected)
+
+
+def _resolution_entry(blackboard: Blackboard, card_id: str, content: str) -> Entry:
+    return Entry(
+        id=card_id,
+        type="duplicate_name_resolution",
+        content=content,
+        created_by=WorkerRecord(
+            "entity_maintenance", "duplicate_name_resolution", blackboard.iteration,
+        ),
+        confidence=1.0,
+        source=None,
+    )
+
+
+def _fingerprint(entry: Entry) -> str | None:
+    try:
+        payload = json.loads(entry.content)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return payload.get("evidence_fingerprint") if isinstance(payload, dict) else None
+
+
+def _strings(value: object) -> list[str]:
+    return sorted({item for item in value if isinstance(item, str)}) if isinstance(value, list) else []

--- a/src/swarm/entity_maintenance_store.py
+++ b/src/swarm/entity_maintenance_store.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from .models import Entry
+
+
+@dataclass(frozen=True)
+class EntityMaintenanceConfig:
+    entity_resolution_interval_iterations: int = 3
+    entity_profile_min_card_count: int = 2
+    duplicate_review_threshold: float = 0.85
+    entity_repair_max_mentions_per_card: int = 20
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, object]) -> EntityMaintenanceConfig:
+        return cls(
+            entity_resolution_interval_iterations=metadata.get(
+                "entity_resolution_interval_iterations", 3
+            ),
+            entity_profile_min_card_count=metadata.get("entity_profile_min_card_count", 2),
+            duplicate_review_threshold=metadata.get("duplicate_review_threshold", 0.85),
+            entity_repair_max_mentions_per_card=metadata.get(
+                "entity_repair_max_mentions_per_card", 20
+            ),
+        )
+
+
+@dataclass
+class EntityMaintenanceState:
+    schema_version: int = 1
+    processed_card_fingerprints: dict[str, str] = field(default_factory=dict)
+    profiles: dict[str, dict[str, object]] = field(default_factory=dict)
+    candidates: dict[str, dict[str, object]] = field(default_factory=dict)
+    decisions: dict[str, dict[str, object]] = field(default_factory=dict)
+    runs: list[dict[str, object]] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, output_dir: str) -> EntityMaintenanceState:
+        path = _state_path(output_dir)
+        if not path.exists():
+            return cls()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("Entity maintenance state must be a JSON object")
+        return cls(
+            schema_version=data.get("schema_version", 1),
+            processed_card_fingerprints=data.get("processed_card_fingerprints", {}),
+            profiles=data.get("profiles", {}),
+            candidates=data.get("candidates", {}),
+            decisions=data.get("decisions", {}),
+            runs=data.get("runs", []),
+        )
+
+    def write(self, output_dir: str) -> Path:
+        path = _state_path(output_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            {
+                "schema_version": self.schema_version,
+                "processed_card_fingerprints": self.processed_card_fingerprints,
+                "profiles": self.profiles,
+                "candidates": self.candidates,
+                "decisions": self.decisions,
+                "runs": self.runs,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        temporary_path = path.with_name(f".{path.name}.tmp")
+        temporary_path.write_text(payload, encoding="utf-8")
+        temporary_path.replace(path)
+        return path
+
+    def card_is_dirty(self, entry: Entry) -> bool:
+        return self.processed_card_fingerprints.get(entry.id) != self.fingerprint(entry)
+
+    def mark_cards_processed(self, entries: Iterable[Entry]) -> None:
+        for entry in entries:
+            self.processed_card_fingerprints[entry.id] = self.fingerprint(entry)
+
+    def fingerprint(self, payload: object) -> str:
+        if isinstance(payload, Entry):
+            payload = {
+                "id": payload.id,
+                "content": payload.content,
+                "source": (
+                    {
+                        "document": payload.source.document,
+                        "section": payload.source.section,
+                        "evidence": payload.source.evidence,
+                    }
+                    if payload.source else None
+                ),
+                "status": payload.status,
+                "direct_document_context": payload.direct_document_context,
+                "entities": payload.entities,
+                "entity_annotation_provenance": payload.entity_annotation_provenance,
+            }
+        canonical = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def _state_path(output_dir: str) -> Path:
+    return Path(output_dir) / "swarm" / "entity_resolution" / "state.json"

--- a/src/swarm/entity_mention_repair.py
+++ b/src/swarm/entity_mention_repair.py
@@ -15,6 +15,12 @@ class RepairSummary:
     untyped_mentions: int = 0
 
 
+def entity_profile_id(entity_type: str, name: str) -> str:
+    """Return the one profile-ID format used by workers and deterministic repair."""
+    normalized_name = "-".join(re.findall(r"[\w]+", name.casefold()))
+    return f"{entity_type}:{normalized_name}"
+
+
 def eligible_direct_entries(entries: Iterable[Entry]) -> tuple[Entry, ...]:
     return tuple(
         entry for entry in entries
@@ -41,11 +47,13 @@ def build_entity_catalogue(
         if not normalized:
             return
         safe_type = _safe_entity_type(entity_type)
-        canonical_profile_id = (
-            profile_id if isinstance(profile_id, str) and profile_id else
-            f"{safe_type or 'untyped'}:{normalized}"
-        )
-        key = f"{safe_type or 'untyped'}:{normalized}"
+        canonical_profile_id = entity_profile_id(safe_type or "untyped", name)
+        if isinstance(profile_id, str) and profile_id:
+            _, _, profile_name = profile_id.partition(":")
+            canonical_profile_id = entity_profile_id(
+                safe_type or "untyped", profile_name or name,
+            )
+        key = entity_profile_id(safe_type or "untyped", name)
         record = {
             "entity_type": safe_type,
             "normalized_name": normalized,

--- a/src/swarm/entity_mention_repair.py
+++ b/src/swarm/entity_mention_repair.py
@@ -40,7 +40,7 @@ def build_entity_catalogue(
         normalized = _normalized_name(name)
         if not normalized:
             return
-        safe_type = entity_type if entity_type in ENTITY_TYPES else None
+        safe_type = _safe_entity_type(entity_type)
         canonical_profile_id = (
             profile_id if isinstance(profile_id, str) and profile_id else
             f"{safe_type or 'untyped'}:{normalized}"
@@ -67,7 +67,7 @@ def build_entity_catalogue(
             for alias in aliases:
                 add_candidate(alias, entity_type, profile_id, source_rank=0)
 
-    for entry in eligible_direct_entries(entries):
+    for entry in sorted(eligible_direct_entries(entries), key=lambda entry: entry.id):
         for index, annotation in enumerate(entry.entities):
             if not isinstance(annotation, Mapping):
                 continue
@@ -77,6 +77,8 @@ def build_entity_catalogue(
                 and isinstance(entry.entity_annotation_provenance[index], Mapping)
                 else {}
             )
+            if provenance.get("method") not in ("worker", "deterministic_repair"):
+                continue
             add_candidate(
                 annotation.get("name"),
                 annotation.get("entity_type"),
@@ -102,7 +104,7 @@ def repair_entity_mentions(
     repaired_mentions = 0
     untyped_mentions = 0
 
-    for entry in eligible_direct_entries(entries):
+    for entry in sorted(eligible_direct_entries(entries), key=lambda entry: entry.id):
         if max_mentions_per_card <= len(entry.entities):
             continue
         text = f"{entry.content}\n{entry.source.evidence if entry.source else ''}"
@@ -124,8 +126,8 @@ def repair_entity_mentions(
                 continue
 
             observed_text = _normalize_whitespace(matched.group("mention"))
-            entity_type = candidate["entity_type"]
-            if entity_type in ENTITY_TYPES:
+            entity_type = _safe_entity_type(candidate["entity_type"])
+            if entity_type is not None:
                 entry.entities.append({
                     "entity_type": entity_type,
                     "name": observed_text,
@@ -170,7 +172,7 @@ def _catalogue_candidates(
             entity_type = record.get("entity_type")
             profile_id = record.get("profile_id", key)
             records.append({
-                "entity_type": entity_type if entity_type in ENTITY_TYPES else None,
+                "entity_type": _safe_entity_type(entity_type),
                 "normalized_name": _normalized_name(normalized),
                 "profile_id": profile_id if isinstance(profile_id, str) else str(key),
             })
@@ -206,3 +208,7 @@ def _literal_match(text: str, normalized_name: str) -> re.Match[str] | None:
     tokens = normalized_name.split(" ")
     literal = r"\s+".join(re.escape(token) for token in tokens)
     return re.search(rf"(?<!\w)(?P<mention>{literal})(?!\w)", text, re.IGNORECASE)
+
+
+def _safe_entity_type(value: object) -> str | None:
+    return value if isinstance(value, str) and value in ENTITY_TYPES else None

--- a/src/swarm/entity_mention_repair.py
+++ b/src/swarm/entity_mention_repair.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from .entity_annotations import ENTITY_TYPES
+from .models import Entry
+
+
+@dataclass(frozen=True)
+class RepairSummary:
+    changed_card_ids: tuple[str, ...] = ()
+    repaired_mentions: int = 0
+    untyped_mentions: int = 0
+
+
+def eligible_direct_entries(entries: Iterable[Entry]) -> tuple[Entry, ...]:
+    return tuple(
+        entry for entry in entries
+        if entry.status == "active" and entry.direct_document_context
+    )
+
+
+def build_entity_catalogue(
+    entries: Iterable[Entry], profiles: Mapping[str, Mapping[str, object]]
+) -> Mapping[str, Mapping[str, object]]:
+    """Collect deterministic literal-match candidates from direct worker cards and profiles."""
+    candidates: dict[str, tuple[tuple[int, str, str], dict[str, object]]] = {}
+
+    def add_candidate(
+        name: object,
+        entity_type: object,
+        profile_id: object,
+        *,
+        source_rank: int,
+    ) -> None:
+        if not isinstance(name, str):
+            return
+        normalized = _normalized_name(name)
+        if not normalized:
+            return
+        safe_type = entity_type if entity_type in ENTITY_TYPES else None
+        canonical_profile_id = (
+            profile_id if isinstance(profile_id, str) and profile_id else
+            f"{safe_type or 'untyped'}:{normalized}"
+        )
+        key = f"{safe_type or 'untyped'}:{normalized}"
+        record = {
+            "entity_type": safe_type,
+            "normalized_name": normalized,
+            "profile_id": canonical_profile_id,
+        }
+        priority = (source_rank, canonical_profile_id, name)
+        current = candidates.get(key)
+        if current is None or priority < current[0]:
+            candidates[key] = (priority, record)
+
+    for profile_id, profile in profiles.items():
+        if not isinstance(profile, Mapping):
+            continue
+        entity_type = profile.get("entity_type")
+        primary_name = profile.get("primary_name", profile.get("name"))
+        add_candidate(primary_name, entity_type, profile_id, source_rank=0)
+        aliases = profile.get("aliases", ())
+        if isinstance(aliases, Iterable) and not isinstance(aliases, (str, bytes, Mapping)):
+            for alias in aliases:
+                add_candidate(alias, entity_type, profile_id, source_rank=0)
+
+    for entry in eligible_direct_entries(entries):
+        for index, annotation in enumerate(entry.entities):
+            if not isinstance(annotation, Mapping):
+                continue
+            provenance = (
+                entry.entity_annotation_provenance[index]
+                if index < len(entry.entity_annotation_provenance)
+                and isinstance(entry.entity_annotation_provenance[index], Mapping)
+                else {}
+            )
+            add_candidate(
+                annotation.get("name"),
+                annotation.get("entity_type"),
+                provenance.get("profile_id"),
+                source_rank=1,
+            )
+
+    return {
+        key: record
+        for key, (_, record) in sorted(candidates.items())
+    }
+
+
+def repair_entity_mentions(
+    entries: Iterable[Entry],
+    catalogue: Mapping[str, Mapping[str, object]],
+    max_mentions_per_card: int,
+    run_id: str,
+) -> RepairSummary:
+    """Append only missing, literal entity mentions on active direct-document cards."""
+    candidates = _catalogue_candidates(catalogue)
+    changed_card_ids: list[str] = []
+    repaired_mentions = 0
+    untyped_mentions = 0
+
+    for entry in eligible_direct_entries(entries):
+        if max_mentions_per_card <= len(entry.entities):
+            continue
+        text = f"{entry.content}\n{entry.source.evidence if entry.source else ''}"
+        existing_names = {
+            _normalized_name(annotation.get("name"))
+            for annotation in entry.entities
+            if isinstance(annotation, Mapping) and isinstance(annotation.get("name"), str)
+        }
+        changed = False
+
+        for candidate in candidates:
+            if max_mentions_per_card <= len(entry.entities):
+                break
+            normalized = candidate["normalized_name"]
+            if normalized in existing_names:
+                continue
+            matched = _literal_match(text, normalized)
+            if matched is None:
+                continue
+
+            observed_text = _normalize_whitespace(matched.group("mention"))
+            entity_type = candidate["entity_type"]
+            if entity_type in ENTITY_TYPES:
+                entry.entities.append({
+                    "entity_type": entity_type,
+                    "name": observed_text,
+                    "attributes": [],
+                })
+                entry.entity_annotation_provenance.append({
+                    "method": "deterministic_repair",
+                    "matched_text": observed_text,
+                    "profile_id": candidate["profile_id"],
+                    "run_id": run_id,
+                })
+                existing_names.add(normalized)
+                repaired_mentions += 1
+                changed = True
+                continue
+
+            rejection = f"untyped_repaired_mention:{normalized}"
+            if rejection not in entry.entity_annotation_rejections:
+                entry.entity_annotation_rejections.append(rejection)
+                untyped_mentions += 1
+                changed = True
+
+        if changed:
+            changed_card_ids.append(entry.id)
+
+    return RepairSummary(
+        changed_card_ids=tuple(changed_card_ids),
+        repaired_mentions=repaired_mentions,
+        untyped_mentions=untyped_mentions,
+    )
+
+
+def _catalogue_candidates(
+    catalogue: Mapping[str, Mapping[str, object]],
+) -> tuple[dict[str, object], ...]:
+    records: list[dict[str, object]] = []
+    for key, record in catalogue.items():
+        if not isinstance(record, Mapping):
+            continue
+        normalized = record.get("normalized_name")
+        if isinstance(normalized, str) and normalized:
+            entity_type = record.get("entity_type")
+            profile_id = record.get("profile_id", key)
+            records.append({
+                "entity_type": entity_type if entity_type in ENTITY_TYPES else None,
+                "normalized_name": _normalized_name(normalized),
+                "profile_id": profile_id if isinstance(profile_id, str) else str(key),
+            })
+            continue
+
+        records.extend(build_entity_catalogue((), {str(key): record}).values())
+
+    unique: dict[tuple[object, str], dict[str, object]] = {}
+    for record in records:
+        identity = (record["entity_type"], record["normalized_name"])
+        current = unique.get(identity)
+        if current is None or str(record["profile_id"]) < str(current["profile_id"]):
+            unique[identity] = record
+    return tuple(sorted(
+        unique.values(),
+        key=lambda record: (
+            -len(str(record["normalized_name"])),
+            str(record["profile_id"]),
+            str(record["entity_type"]),
+        ),
+    ))
+
+
+def _normalized_name(value: str) -> str:
+    return _normalize_whitespace(value).casefold()
+
+
+def _normalize_whitespace(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _literal_match(text: str, normalized_name: str) -> re.Match[str] | None:
+    tokens = normalized_name.split(" ")
+    literal = r"\s+".join(re.escape(token) for token in tokens)
+    return re.search(rf"(?<!\w)(?P<mention>{literal})(?!\w)", text, re.IGNORECASE)

--- a/src/swarm/entity_profiles.py
+++ b/src/swarm/entity_profiles.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from .blackboard import Blackboard
+from .entity_annotations import ENTITY_TYPES
+from .entity_maintenance_store import EntityMaintenanceState
+from .entity_mention_repair import eligible_direct_entries
+from .models import Entry, WorkerRecord
+
+
+@dataclass(frozen=True)
+class ProfileRefreshSummary:
+    dirty_profile_ids: tuple[str, ...] = ()
+    created_profile_ids: tuple[str, ...] = ()
+    updated_profile_ids: tuple[str, ...] = ()
+
+
+def refresh_entity_profiles(
+    state: EntityMaintenanceState,
+    entries: Iterable[Entry],
+    min_card_count: int,
+) -> ProfileRefreshSummary:
+    """Refresh source-linked profiles from active direct-document cards only."""
+    groups: dict[str, list[tuple[Entry, Mapping[str, object], Mapping[str, object]]]] = defaultdict(list)
+    for entry in sorted(eligible_direct_entries(entries), key=lambda item: item.id):
+        if entry.type == "entity_information":
+            continue
+        for index, annotation in enumerate(entry.entities):
+            if not isinstance(annotation, Mapping):
+                continue
+            provenance = _provenance(entry, index)
+            if provenance.get("method") not in {"worker", "deterministic_repair"}:
+                continue
+            entity_type = annotation.get("entity_type")
+            name = annotation.get("name")
+            if entity_type not in ENTITY_TYPES or not isinstance(name, str) or not name.strip():
+                continue
+            profile_id = _profile_id(entity_type, name)
+            repaired_profile_id = provenance.get("profile_id")
+            if (
+                provenance.get("method") == "deterministic_repair"
+                and isinstance(repaired_profile_id, str)
+                and repaired_profile_id.startswith(f"{entity_type}:")
+            ):
+                profile_id = repaired_profile_id
+            groups[profile_id].append((entry, annotation, provenance))
+
+    created: list[str] = []
+    updated: list[str] = []
+    for profile_id in sorted(groups):
+        mentions = groups[profile_id]
+        source_card_ids = {entry.id for entry, _, _ in mentions if entry.id}
+        existing = state.profiles.get(profile_id)
+        if existing is None and len(source_card_ids) < min_card_count:
+            continue
+        payload = _profile_payload(profile_id, mentions)
+        fingerprint = _profile_fingerprint(payload)
+        if existing is not None and existing.get("fingerprint") == fingerprint:
+            continue
+        revision = 1 if existing is None else _revision(existing) + 1
+        payload["revision"] = revision
+        payload["fingerprint"] = fingerprint
+        state.profiles[profile_id] = payload
+        (created if existing is None else updated).append(profile_id)
+
+    dirty = tuple(sorted((*created, *updated)))
+    return ProfileRefreshSummary(dirty, tuple(created), tuple(updated))
+
+
+def project_entity_information_cards(
+    blackboard: Blackboard,
+    state: EntityMaintenanceState,
+    summary: ProfileRefreshSummary,
+) -> tuple[str, ...]:
+    """Project each changed profile to its single concise current context card."""
+    projected: list[str] = []
+    for profile_id in sorted(summary.dirty_profile_ids):
+        profile = state.profiles.get(profile_id)
+        if not isinstance(profile, Mapping):
+            continue
+        card_id = f"entity-info-{profile_id.replace(':', '-')}"
+        content = json.dumps(_card_payload(profile), sort_keys=True, separators=(",", ":"))
+        card = blackboard.find_entry(card_id)
+        if card is None:
+            blackboard.add_entry(Entry(
+                id=card_id,
+                type="entity_information",
+                content=content,
+                created_by=WorkerRecord(
+                    "entity_maintenance", "entity_information", blackboard.iteration,
+                ),
+                confidence=1.0,
+                source=None,
+            ))
+        else:
+            card.type = "entity_information"
+            card.content = content
+            card.source = None
+            card.created_by = WorkerRecord(
+                "entity_maintenance", "entity_information", blackboard.iteration,
+            )
+            card.confidence = 1.0
+            card.status = "active"
+        projected.append(card_id)
+    return tuple(projected)
+
+
+def _profile_payload(
+    profile_id: str,
+    mentions: list[tuple[Entry, Mapping[str, object], Mapping[str, object]]],
+) -> dict[str, object]:
+    entity_type, _ = profile_id.split(":", 1)
+    names = sorted({str(annotation["name"]).strip() for _, annotation, _ in mentions}, key=_name_sort_key)
+    primary_name = names[0]
+    aliases = set(names[1:])
+    facts: dict[tuple[str, str, str], dict[str, object]] = {}
+
+    for entry, annotation, _ in mentions:
+        name = str(annotation["name"]).strip()
+        _add_fact(facts, entry, "name", name)
+        attributes = annotation.get("attributes", [])
+        if not isinstance(attributes, list):
+            continue
+        for attribute in attributes:
+            if not isinstance(attribute, Mapping):
+                continue
+            field, value = attribute.get("kind"), attribute.get("value")
+            if not isinstance(field, str) or not field.strip() or not isinstance(value, str) or not value.strip():
+                continue
+            value = value.strip()
+            _add_fact(facts, entry, field.strip(), value)
+            if field == "alias" and value != primary_name:
+                aliases.add(value)
+
+    return {
+        "profile_id": profile_id,
+        "entity_type": entity_type,
+        "primary_name": primary_name,
+        "aliases": sorted(alias for alias in aliases if alias),
+        "source_card_ids": sorted({entry.id for entry, _, _ in mentions if entry.id}),
+        "facts": [facts[key] for key in sorted(facts)],
+    }
+
+
+def _add_fact(
+    facts: dict[tuple[str, str, str], dict[str, object]],
+    entry: Entry,
+    field: str,
+    value: str,
+) -> None:
+    normalized_value = _normalized_value(value)
+    key = (field, normalized_value, entry.id)
+    if key in facts:
+        return
+    quote = entry.source.evidence if entry.source else ""
+    facts[key] = {
+        "field": field,
+        "value": value,
+        "normalized_value": normalized_value,
+        "source_card_id": entry.id,
+        "source_document": entry.source.document if entry.source else None,
+        "source_section": entry.source.section if entry.source else None,
+        "quote": quote,
+        "provenance_quality": "quoted_direct" if value in quote else "direct_worker_context",
+        "status": "observed",
+    }
+
+
+def _card_payload(profile: Mapping[str, object]) -> dict[str, object]:
+    facts_by_field: dict[str, list[str]] = {}
+    for fact in profile.get("facts", []):
+        if not isinstance(fact, Mapping):
+            continue
+        field, value = fact.get("field"), fact.get("value")
+        if isinstance(field, str) and isinstance(value, str):
+            facts_by_field.setdefault(field, []).append(value)
+    return {
+        "profile_id": profile.get("profile_id", ""),
+        "primary_name": profile.get("primary_name", ""),
+        "aliases": profile.get("aliases", []),
+        "facts": {
+            field: sorted(set(values), key=_name_sort_key)
+            for field, values in sorted(facts_by_field.items())
+        },
+        "revision": profile.get("revision", 1),
+    }
+
+
+def _provenance(entry: Entry, index: int) -> Mapping[str, object]:
+    if index < len(entry.entity_annotation_provenance):
+        provenance = entry.entity_annotation_provenance[index]
+        if isinstance(provenance, Mapping):
+            return provenance
+    return {}
+
+
+def _profile_id(entity_type: str, name: str) -> str:
+    normalized_name = "-".join(re.findall(r"[\w]+", name.casefold()))
+    return f"{entity_type}:{normalized_name}"
+
+
+def _normalized_value(value: str) -> str:
+    return "".join(re.findall(r"\w+", value.casefold()))
+
+
+def _name_sort_key(value: str) -> tuple[str, str]:
+    return (value.casefold(), value)
+
+
+def _profile_fingerprint(payload: Mapping[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "profile_fp_" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def _revision(profile: Mapping[str, object]) -> int:
+    revision = profile.get("revision", 0)
+    return revision if isinstance(revision, int) and revision >= 1 else 0

--- a/src/swarm/entity_profiles.py
+++ b/src/swarm/entity_profiles.py
@@ -134,7 +134,11 @@ def _profile_payload(
             if not isinstance(field, str) or not field.strip() or not isinstance(value, str) or not value.strip():
                 continue
             value = value.strip()
-            _add_fact(facts, entry, field.strip(), value)
+            _add_fact(
+                facts, entry, field.strip(), value,
+                verified=attribute.get("verified") is True,
+                qualifiers=_qualifiers(attribute.get("qualifiers")),
+            )
             if field == "alias" and value != primary_name:
                 aliases.add(value)
 
@@ -153,6 +157,9 @@ def _add_fact(
     entry: Entry,
     field: str,
     value: str,
+    *,
+    verified: bool = False,
+    qualifiers: dict[str, str] | None = None,
 ) -> None:
     normalized_value = _normalized_value(value)
     key = (field, normalized_value, entry.id)
@@ -169,6 +176,8 @@ def _add_fact(
         "quote": quote,
         "provenance_quality": "quoted_direct" if value in quote else "direct_worker_context",
         "status": "observed",
+        "verified": verified,
+        "qualifiers": qualifiers or {},
     }
 
 
@@ -189,6 +198,16 @@ def _card_payload(profile: Mapping[str, object]) -> dict[str, object]:
             for field, values in sorted(facts_by_field.items())
         },
         "revision": profile.get("revision", 1),
+    }
+
+
+def _qualifiers(value: object) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        key: item
+        for key, item in sorted(value.items())
+        if isinstance(key, str) and key and isinstance(item, str) and item
     }
 
 

--- a/src/swarm/entity_profiles.py
+++ b/src/swarm/entity_profiles.py
@@ -19,6 +19,7 @@ class ProfileRefreshSummary:
     dirty_profile_ids: tuple[str, ...] = ()
     created_profile_ids: tuple[str, ...] = ()
     updated_profile_ids: tuple[str, ...] = ()
+    retired_profile_ids: tuple[str, ...] = ()
 
 
 def refresh_entity_profiles(
@@ -51,6 +52,15 @@ def refresh_entity_profiles(
                 profile_id = repaired_profile_id
             groups[profile_id].append((entry, annotation, provenance))
 
+    supported_profile_ids = {
+        profile_id
+        for profile_id, mentions in groups.items()
+        if len({entry.id for entry, _, _ in mentions if entry.id}) >= min_card_count
+    }
+    retired = tuple(sorted(set(state.profiles) - supported_profile_ids))
+    for profile_id in retired:
+        del state.profiles[profile_id]
+
     created: list[str] = []
     updated: list[str] = []
     for profile_id in sorted(groups):
@@ -70,7 +80,7 @@ def refresh_entity_profiles(
         (created if existing is None else updated).append(profile_id)
 
     dirty = tuple(sorted((*created, *updated)))
-    return ProfileRefreshSummary(dirty, tuple(created), tuple(updated))
+    return ProfileRefreshSummary(dirty, tuple(created), tuple(updated), retired)
 
 
 def project_entity_information_cards(
@@ -80,6 +90,10 @@ def project_entity_information_cards(
 ) -> tuple[str, ...]:
     """Project each changed profile to its single concise current context card."""
     projected: list[str] = []
+    for profile_id in summary.retired_profile_ids:
+        card = blackboard.find_entry(f"entity-info-{profile_id.replace(':', '-')}")
+        if card is not None:
+            card.status = "superseded"
     for profile_id in sorted(summary.dirty_profile_ids):
         profile = state.profiles.get(profile_id)
         if not isinstance(profile, Mapping):

--- a/src/swarm/entity_profiles.py
+++ b/src/swarm/entity_profiles.py
@@ -7,11 +7,10 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
-from .blackboard import Blackboard
 from .entity_annotations import ENTITY_TYPES
 from .entity_maintenance_store import EntityMaintenanceState
 from .entity_mention_repair import eligible_direct_entries
-from .models import Entry, WorkerRecord
+from .models import Entry
 
 
 @dataclass(frozen=True)
@@ -30,8 +29,6 @@ def refresh_entity_profiles(
     """Refresh source-linked profiles from active direct-document cards only."""
     groups: dict[str, list[tuple[Entry, Mapping[str, object], Mapping[str, object]]]] = defaultdict(list)
     for entry in sorted(eligible_direct_entries(entries), key=lambda item: item.id):
-        if entry.type == "entity_information":
-            continue
         for index, annotation in enumerate(entry.entities):
             if not isinstance(annotation, Mapping):
                 continue
@@ -81,48 +78,6 @@ def refresh_entity_profiles(
 
     dirty = tuple(sorted((*created, *updated)))
     return ProfileRefreshSummary(dirty, tuple(created), tuple(updated), retired)
-
-
-def project_entity_information_cards(
-    blackboard: Blackboard,
-    state: EntityMaintenanceState,
-    summary: ProfileRefreshSummary,
-) -> tuple[str, ...]:
-    """Project each changed profile to its single concise current context card."""
-    projected: list[str] = []
-    for profile_id in summary.retired_profile_ids:
-        card = blackboard.find_entry(f"entity-info-{profile_id.replace(':', '-')}")
-        if card is not None:
-            card.status = "superseded"
-    for profile_id in sorted(summary.dirty_profile_ids):
-        profile = state.profiles.get(profile_id)
-        if not isinstance(profile, Mapping):
-            continue
-        card_id = f"entity-info-{profile_id.replace(':', '-')}"
-        content = json.dumps(_card_payload(profile), sort_keys=True, separators=(",", ":"))
-        card = blackboard.find_entry(card_id)
-        if card is None:
-            blackboard.add_entry(Entry(
-                id=card_id,
-                type="entity_information",
-                content=content,
-                created_by=WorkerRecord(
-                    "entity_maintenance", "entity_information", blackboard.iteration,
-                ),
-                confidence=1.0,
-                source=None,
-            ))
-        else:
-            card.type = "entity_information"
-            card.content = content
-            card.source = None
-            card.created_by = WorkerRecord(
-                "entity_maintenance", "entity_information", blackboard.iteration,
-            )
-            card.confidence = 1.0
-            card.status = "active"
-        projected.append(card_id)
-    return tuple(projected)
 
 
 def _profile_payload(
@@ -192,26 +147,6 @@ def _add_fact(
         "status": "observed",
         "verified": verified,
         "qualifiers": qualifiers or {},
-    }
-
-
-def _card_payload(profile: Mapping[str, object]) -> dict[str, object]:
-    facts_by_field: dict[str, list[str]] = {}
-    for fact in profile.get("facts", []):
-        if not isinstance(fact, Mapping):
-            continue
-        field, value = fact.get("field"), fact.get("value")
-        if isinstance(field, str) and isinstance(value, str):
-            facts_by_field.setdefault(field, []).append(value)
-    return {
-        "profile_id": profile.get("profile_id", ""),
-        "primary_name": profile.get("primary_name", ""),
-        "aliases": profile.get("aliases", []),
-        "facts": {
-            field: sorted(set(values), key=_name_sort_key)
-            for field, values in sorted(facts_by_field.items())
-        },
-        "revision": profile.get("revision", 1),
     }
 
 

--- a/src/swarm/entity_profiles.py
+++ b/src/swarm/entity_profiles.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 from .entity_annotations import ENTITY_TYPES
 from .entity_maintenance_store import EntityMaintenanceState
-from .entity_mention_repair import eligible_direct_entries
+from .entity_mention_repair import eligible_direct_entries, entity_profile_id
 from .models import Entry
 
 
@@ -39,14 +39,16 @@ def refresh_entity_profiles(
             name = annotation.get("name")
             if entity_type not in ENTITY_TYPES or not isinstance(name, str) or not name.strip():
                 continue
-            profile_id = _profile_id(entity_type, name)
+            profile_id = entity_profile_id(entity_type, name)
             repaired_profile_id = provenance.get("profile_id")
             if (
                 provenance.get("method") == "deterministic_repair"
                 and isinstance(repaired_profile_id, str)
                 and repaired_profile_id.startswith(f"{entity_type}:")
             ):
-                profile_id = repaired_profile_id
+                profile_id = entity_profile_id(
+                    entity_type, repaired_profile_id.split(":", 1)[1],
+                )
             groups[profile_id].append((entry, annotation, provenance))
 
     supported_profile_ids = {
@@ -166,11 +168,6 @@ def _provenance(entry: Entry, index: int) -> Mapping[str, object]:
         if isinstance(provenance, Mapping):
             return provenance
     return {}
-
-
-def _profile_id(entity_type: str, name: str) -> str:
-    normalized_name = "-".join(re.findall(r"[\w]+", name.casefold()))
-    return f"{entity_type}:{normalized_name}"
 
 
 def _normalized_value(value: str) -> str:

--- a/src/swarm/entity_specialist_review.py
+++ b/src/swarm/entity_specialist_review.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from .entity_maintenance_store import EntityMaintenanceState
+from .models import ModelCaller
+from .worker_dispatch import parse_json_object
+
+
+CONFIRMED_OUTCOMES = frozenset({"same_entity", "same_name_distinct_entity"})
+_OUTCOMES = CONFIRMED_OUTCOMES | {"uncertain"}
+
+
+@dataclass(frozen=True)
+class SpecialistReviewSummary:
+    model_calls: int = 0
+    reviewed_candidate_ids: tuple[str, ...] = ()
+    retry_candidate_ids: tuple[str, ...] = ()
+
+
+def review_pending_candidates(
+    state: EntityMaintenanceState,
+    candidate_ids: Sequence[str],
+    caller: ModelCaller,
+) -> SpecialistReviewSummary:
+    """Review eligible candidates once each and retain every result in the sidecar."""
+    reviewed: list[str] = []
+    retries: list[str] = []
+    calls = 0
+    for candidate_id in sorted(set(candidate_ids)):
+        candidate = state.candidates.get(candidate_id)
+        if not isinstance(candidate, dict) or candidate.get("status") not in {
+            "pending_review", "review_retry",
+        }:
+            continue
+        calls += 1
+        try:
+            result = caller.complete(_prompt(candidate, state.profiles), max_tokens=1024)
+        except Exception as exc:
+            candidate["status"] = "review_retry"
+            candidate["last_error"] = f"{type(exc).__name__}: {exc}"
+            state.runs.append({
+                "stage": "entity_specialist_review",
+                "candidate_id": candidate_id,
+                "error": candidate["last_error"],
+            })
+            retries.append(candidate_id)
+            continue
+
+        payload = parse_json_object(result.text)
+        decision = _validated_decision(payload, _source_quotes(candidate, state.profiles))
+        if decision is None:
+            decision = {
+                "decision": "uncertain",
+                "rationale": "The specialist response did not meet the source-citation contract.",
+                "citations": [],
+            }
+        outcome = str(decision["decision"])
+        decision_id = _decision_id(str(candidate.get("semantic_key", candidate_id)))
+        source_card_ids = sorted({
+            citation["source_card_id"] for citation in decision["citations"]
+        })
+        state.decisions[decision_id] = {
+            "decision_id": decision_id,
+            "candidate_id": candidate_id,
+            "semantic_key": candidate.get("semantic_key", candidate_id),
+            "outcome": outcome,
+            "evidence_fingerprint": candidate.get("evidence_fingerprint", ""),
+            "profile_ids": _strings(candidate.get("profile_ids")),
+            "source_card_ids": source_card_ids,
+            "rationale": decision["rationale"],
+            "citations": decision["citations"],
+            "conflicts": _strings(candidate.get("conflicts")),
+        }
+        candidate["status"] = "reviewed" if outcome in CONFIRMED_OUTCOMES else "uncertain"
+        candidate.pop("last_error", None)
+        reviewed.append(candidate_id)
+    return SpecialistReviewSummary(calls, tuple(reviewed), tuple(retries))
+
+
+def _prompt(candidate: Mapping[str, object], profiles: Mapping[str, object]) -> str:
+    profile_ids = _strings(candidate.get("profile_ids"))
+    relevant_profiles = [
+        _compact_profile(profile_id, profiles.get(profile_id))
+        for profile_id in profile_ids
+        if isinstance(profiles.get(profile_id), Mapping)
+    ]
+    source_quotes = _source_quotes(candidate, profiles)
+    return "\n".join((
+        "Decide whether the source-grounded entity profiles identify the same entity.",
+        "Return exactly this JSON object with no additional keys:",
+        '{"decision":"same_entity | same_name_distinct_entity | uncertain",'
+        '"rationale":"short explanation grounded in supplied cards",'
+        '"citations":[{"source_card_id":"e1","quote":"exact supplied quote"}]}',
+        "Candidate:",
+        json.dumps({
+            "score": candidate.get("score"),
+            "evidence": candidate.get("evidence", []),
+            "conflicts": candidate.get("conflicts", []),
+        }, sort_keys=True, separators=(",", ":")),
+        "Profiles:",
+        json.dumps(relevant_profiles, sort_keys=True, separators=(",", ":")),
+        "Direct worker cards:",
+        json.dumps([
+            {"source_card_id": card_id, "quote": quote}
+            for card_id, quote in sorted(source_quotes.items())
+        ], sort_keys=True, separators=(",", ":")),
+    ))
+
+
+def _compact_profile(profile_id: str, profile: Mapping[str, object]) -> dict[str, object]:
+    facts = profile.get("facts", [])
+    return {
+        "profile_id": profile_id,
+        "entity_type": profile.get("entity_type"),
+        "primary_name": profile.get("primary_name"),
+        "aliases": profile.get("aliases", []),
+        "facts": [
+            {
+                key: fact[key]
+                for key in ("field", "value", "source_card_id", "verified", "qualifiers")
+                if key in fact
+            }
+            for fact in facts
+            if isinstance(fact, Mapping)
+        ],
+    }
+
+
+def _source_quotes(
+    candidate: Mapping[str, object], profiles: Mapping[str, object],
+) -> dict[str, str]:
+    allowed = {
+        card_id
+        for group in candidate.get("source_card_groups", [])
+        if isinstance(group, list)
+        for card_id in group
+        if isinstance(card_id, str)
+    }
+    quotes: dict[str, str] = {}
+    for profile_id in _strings(candidate.get("profile_ids")):
+        profile = profiles.get(profile_id)
+        if not isinstance(profile, Mapping):
+            continue
+        facts = profile.get("facts", [])
+        if not isinstance(facts, list):
+            continue
+        for fact in facts:
+            if not isinstance(fact, Mapping):
+                continue
+            card_id, quote = fact.get("source_card_id"), fact.get("quote")
+            if (
+                isinstance(card_id, str)
+                and card_id in allowed
+                and isinstance(quote, str)
+                and quote.strip()
+            ):
+                quotes.setdefault(card_id, quote)
+    return quotes
+
+
+def _validated_decision(
+    payload: object, source_quotes: Mapping[str, str],
+) -> dict[str, object] | None:
+    if not isinstance(payload, Mapping) or set(payload) != {"decision", "rationale", "citations"}:
+        return None
+    outcome, rationale, citations = payload.get("decision"), payload.get("rationale"), payload.get("citations")
+    if outcome not in _OUTCOMES or not isinstance(rationale, str) or not rationale.strip():
+        return None
+    if not isinstance(citations, list) or not citations:
+        return None
+    validated: list[dict[str, str]] = []
+    for citation in citations:
+        if not isinstance(citation, Mapping) or set(citation) != {"source_card_id", "quote"}:
+            return None
+        card_id, quote = citation.get("source_card_id"), citation.get("quote")
+        if (
+            not isinstance(card_id, str)
+            or not isinstance(quote, str)
+            or not quote.strip()
+            or card_id not in source_quotes
+            or quote not in source_quotes[card_id]
+        ):
+            return None
+        validated.append({"source_card_id": card_id, "quote": quote})
+    return {
+        "decision": outcome,
+        "rationale": rationale.strip(),
+        "citations": validated,
+    }
+
+
+def _decision_id(semantic_key: str) -> str:
+    digest = hashlib.sha256(semantic_key.encode("utf-8")).hexdigest()[:16]
+    return f"entity-decision-{digest}"
+
+
+def _strings(value: object) -> list[str]:
+    return sorted({item for item in value if isinstance(item, str)}) if isinstance(value, list) else []

--- a/src/swarm/models.py
+++ b/src/swarm/models.py
@@ -150,6 +150,10 @@ class Entry:
     contradicts_entries: list[str] = field(default_factory=list)
     supersedes_entries: list[str] = field(default_factory=list)
     addresses_signals: list[str] = field(default_factory=list)
+    direct_document_context: bool = False
+    entities: list[dict[str, Any]] = field(default_factory=list)
+    entity_annotation_rejections: list[str] = field(default_factory=list)
+    entity_annotation_provenance: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -167,6 +171,10 @@ class Entry:
             "supports": self.supports_entries, "contradicts": self.contradicts_entries,
             "supersedes": self.supersedes_entries,
             "addresses_signals": self.addresses_signals,
+            "direct_document_context": self.direct_document_context,
+            "entities": self.entities,
+            "entity_annotation_rejections": self.entity_annotation_rejections,
+            "entity_annotation_provenance": self.entity_annotation_provenance,
         }
 
 

--- a/src/swarm/worker_dispatch.py
+++ b/src/swarm/worker_dispatch.py
@@ -9,6 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from .blackboard import Blackboard
+from .entity_annotations import validate_entity_annotation_result
 from .models import (
     Entry, EntrySource, EpistemicStatus, ModelCaller, WorkerOutput, WorkerRecord,
     gen_entry_id,
@@ -17,6 +18,31 @@ from .section_index import resolve_section_text
 
 
 _usage_state = threading.local()
+
+
+ENTITY_ANNOTATION_INSTRUCTIONS = r'''
+OPTIONAL ENTITY ANNOTATIONS FOR EACH SOURCE-BACKED FINDING:
+"entities": [
+  {
+    "entity_type": "company | person",
+    "name": "name exactly as written in this card's source evidence",
+    "attributes": [
+      {
+        "kind": "source-local attribute kind",
+        "value": "value exactly supported by this card's evidence",
+        "verified": false,
+        "qualifiers": {"issuer": "required for verified government_id", "identifier_type": "required for verified government_id"}
+      }
+    ]
+  }
+]
+- Annotate every company and natural person literally named in this finding's content or evidence.
+- Do not infer unnamed entities or assemble a profile across cards.
+- Attach an attribute only when this card's evidence explicitly connects the value to that entity.
+- Use verified=true only for a government ID or birth date explicitly shown by an authoritative source; quote the exact value in evidence.
+- For a verified government ID, issuer and identifier_type are mandatory.
+- Use an empty entities array when the finding names no company or natural person.
+'''.strip()
 
 
 def parse_json_object(text: str) -> dict | None:
@@ -212,6 +238,7 @@ RULES:
 - If you cannot determine something, return type "gap"
 - Aim for HIGH DENSITY: 15-40 findings per worker call. Fewer than 10 means you are summarizing.
 """)
+    parts.append(ENTITY_ANNOTATION_INSTRUCTIONS)
     return "\n".join(parts)
 
 
@@ -268,7 +295,8 @@ def _attach_assigned_signal_ids(entries: list[Entry], signal_ids: list[str]) -> 
 
 def parse_worker_output(payload: dict, iteration: int,
                         worker_id: str, task_description: str,
-                        valid_doc_names: set[str] | None = None) -> list[Entry]:
+                        valid_doc_names: set[str] | None = None, *,
+                        direct_document_context: bool = False) -> list[Entry]:
     findings = payload.get("findings", [])
     entries = []
     for f in findings:
@@ -303,6 +331,12 @@ def parse_worker_output(payload: dict, iteration: int,
             f.get("epistemic_classification", "inference"), "unknown",
             str(f.get("epistemic_motivation", "")),
         )
+        annotation_validation = validate_entity_annotation_result(
+            f.get("entities", []), source.evidence if source else "",
+            require_literal_evidence=(
+                not direct_document_context or bool(source and source.evidence.strip())
+            ),
+        )
 
         try:
             conf = float(f.get("confidence", 0.5))
@@ -323,6 +357,10 @@ def parse_worker_output(payload: dict, iteration: int,
             contradicts_entries=_as_list(f.get("contradicts_entries", [])),
             supersedes_entries=_as_list(f.get("supersedes_entries", [])),
             addresses_signals=_as_list(f.get("addresses_signals", [])),
+            direct_document_context=direct_document_context,
+            entities=annotation_validation.annotations,
+            entity_annotation_rejections=list(annotation_validation.rejections),
+            entity_annotation_provenance=[{"method": "worker"} for _ in annotation_validation.annotations],
         ))
     return entries
 
@@ -436,6 +474,7 @@ def execute_workers_parallel(worker_tasks: list[dict], blackboard: Blackboard,
         entries = parse_worker_output(
             payload, blackboard.iteration, wid, task["description"],
             valid_doc_names=_valid_docs,
+            direct_document_context=bool(doc_sections),
         )
         _attach_assigned_signal_ids(entries, assigned_ids)
         return WorkerOutput(entries, tokens, t_in, t_out, result.model, wid, task, sections_read)

--- a/src/swarm/worker_dispatch.py
+++ b/src/swarm/worker_dispatch.py
@@ -326,6 +326,10 @@ def parse_worker_output(payload: dict, iteration: int,
                 raw_doc, f.get("source_section"),
                 str(f.get("evidence", "")),
             )
+        elif direct_document_context and str(f.get("evidence", "")).strip():
+            source = EntrySource(
+                None, f.get("source_section"), str(f.get("evidence", "")),
+            )
 
         epistemic = EpistemicStatus(
             f.get("epistemic_classification", "inference"), "unknown",

--- a/tests/test_entity_annotations.py
+++ b/tests/test_entity_annotations.py
@@ -1,0 +1,43 @@
+from src.swarm.worker_dispatch import parse_worker_output
+
+
+def test_direct_document_context_keeps_unquoted_worker_entity():
+    entries = parse_worker_output(
+        {"findings": [{
+            "type": "observation",
+            "content": "Northwind Limited signed the agreement.",
+            "source_document": "agreement.pdf",
+            "source_section": "Signature",
+            "entities": [{"entity_type": "company", "name": "Northwind Limited", "attributes": []}],
+        }]},
+        1, "w1", "read", {"agreement.pdf"}, direct_document_context=True,
+    )
+
+    assert entries[0].direct_document_context is True
+    assert entries[0].entities[0]["name"] == "Northwind Limited"
+    assert entries[0].entity_annotation_provenance == [{"method": "worker"}]
+
+
+def test_blackboard_only_worker_is_not_direct_document_context():
+    entries = parse_worker_output(
+        {"findings": [{"type": "analysis", "content": "Northwind Limited is material."}]},
+        2, "w2", "analysis", set(), direct_document_context=False,
+    )
+
+    assert entries[0].direct_document_context is False
+
+
+def test_invalid_entity_annotation_is_audited_without_dropping_card():
+    entries = parse_worker_output(
+        {"findings": [{
+            "type": "observation", "content": "Northwind signed the agreement.",
+            "source_document": "agreement.pdf", "source_section": "Signature",
+            "evidence": "Northwind signed the agreement.",
+            "entities": [{"entity_type": "company", "name": "Invented Co", "attributes": []}],
+        }]},
+        1, "w1", "read", {"agreement.pdf"}, direct_document_context=True,
+    )
+
+    assert len(entries) == 1
+    assert entries[0].entities == []
+    assert entries[0].entity_annotation_rejections == ["entity_name_not_in_evidence"]

--- a/tests/test_entity_annotations.py
+++ b/tests/test_entity_annotations.py
@@ -41,3 +41,17 @@ def test_invalid_entity_annotation_is_audited_without_dropping_card():
     assert len(entries) == 1
     assert entries[0].entities == []
     assert entries[0].entity_annotation_rejections == ["entity_name_not_in_evidence"]
+
+
+def test_direct_document_context_validates_nonempty_evidence_without_source_document():
+    entries = parse_worker_output(
+        {"findings": [{
+            "type": "observation", "content": "Northwind signed the agreement.",
+            "evidence": "Northwind signed the agreement.",
+            "entities": [{"entity_type": "company", "name": "Invented Co", "attributes": []}],
+        }]},
+        1, "w1", "read", {"agreement.pdf"}, direct_document_context=True,
+    )
+
+    assert entries[0].entities == []
+    assert entries[0].entity_annotation_rejections == ["entity_name_not_in_evidence"]

--- a/tests/test_entity_annotations.py
+++ b/tests/test_entity_annotations.py
@@ -1,3 +1,6 @@
+from src import swarm
+from src.swarm.blackboard import Blackboard
+from src.swarm.models import DocumentStatus, SectionIndex, SectionRange, Task
 from src.swarm.worker_dispatch import parse_worker_output
 
 
@@ -55,3 +58,45 @@ def test_direct_document_context_validates_nonempty_evidence_without_source_docu
 
     assert entries[0].entities == []
     assert entries[0].entity_annotation_rejections == ["entity_name_not_in_evidence"]
+
+
+def test_initial_reader_binds_known_source_without_quote_payload(monkeypatch):
+    source_text = "Dimitri Volkov signed the agreement on 1 January 2026. " * 2
+    blackboard = Blackboard(documents=[DocumentStatus(
+        id="d1",
+        name="agreement.pdf",
+        text=source_text,
+        section_index=SectionIndex([SectionRange("Signature", 0, len(source_text), 1)]),
+        sections_unread=["Signature"],
+    )])
+    prompts = []
+
+    def fake_call(caller, prompt, max_tokens):
+        prompts.append(prompt)
+        return {"findings": [
+            {
+                "content": "Dimitri Volkov signed the agreement on 1 January 2026.",
+                "type": "observation",
+            },
+            {
+                "content": "Dmitri K. Volkov signed the agreement on 1 January 2026.",
+                "type": "observation",
+                "source_document": "wrong.pdf",
+                "source_section": "Wrong section",
+            },
+        ]}, 0
+
+    monkeypatch.setattr(swarm, "call_model", fake_call)
+
+    entries, _ = swarm._execute_initial_reading(
+        blackboard, Task("Extract facts", []), object(),
+    )
+
+    assert 'source_document: exactly "agreement.pdf"' not in prompts[0]
+    assert 'source_section: exactly "Signature"' not in prompts[0]
+    assert "evidence: an exact contiguous quote" not in prompts[0]
+    assert [(entry.source.document, entry.source.section) for entry in entries] == [
+        ("agreement.pdf", "Signature"),
+        ("agreement.pdf", "Signature"),
+    ]
+    assert [entry.source.evidence for entry in entries] == ["", ""]

--- a/tests/test_entity_candidate_scoring.py
+++ b/tests/test_entity_candidate_scoring.py
@@ -117,7 +117,7 @@ def test_conflicting_verified_values_within_one_profile_stay_pending_review():
     assert candidate["source_card_groups"] == [["company:zenith-trading-card"], ["zenith-second-card"]]
 
 
-def test_screened_out_blocked_person_pair_with_verified_birth_conflict_is_reviewed():
+def test_unrelated_person_pair_is_not_reviewed_for_birth_conflict_alone():
     state = state_with_profiles(
         person_profile("Alice Smith", "1980-01-01"),
         person_profile("Alice Jones", "1990-02-02"),
@@ -125,7 +125,59 @@ def test_screened_out_blocked_person_pair_with_verified_birth_conflict_is_review
 
     summary = refresh_candidates(state, {"person:alice-smith"}, EntityMaintenanceConfig())
 
-    candidate = state.candidates[summary.review_candidate_ids[0]]
-    assert candidate["profile_ids"] == ["person:alice-jones", "person:alice-smith"]
-    assert candidate["status"] == "pending_review"
+    assert summary.review_candidate_ids == ()
+    candidate = next(iter(state.candidates.values()))
+    assert candidate["status"] == "ignored"
     assert "verified_birth_date_conflict" in candidate["conflicts"]
+
+
+def test_person_spelling_variant_name_only_reaches_specialist_review():
+    dimitri = person_profile("Dimitri Volkov", "1980-01-01")
+    dymitri = person_profile("Dymitri Volkov", "1980-01-01")
+    dimitri["facts"] = []
+    dymitri["facts"] = []
+    state = state_with_profiles(dimitri, dymitri)
+
+    summary = refresh_candidates(state, set(state.profiles), EntityMaintenanceConfig())
+
+    candidate = state.candidates[summary.review_candidate_ids[0]]
+    assert candidate["status"] == "pending_review"
+    assert candidate["evidence"] == ["name:similar"]
+
+
+def test_reordered_abbreviated_person_name_reaches_specialist_review():
+    state = state_with_profiles(
+        person_profile("Dmitri K. Volkov", "1980-01-01"),
+        person_profile("VOLKOV, Dmitriy Konstantinovich", "1980-01-01"),
+    )
+
+    summary = refresh_candidates(state, set(state.profiles), EntityMaintenanceConfig())
+
+    assert len(summary.review_candidate_ids) == 1
+
+
+def test_confirmed_pair_is_not_reviewed_again_when_only_profile_revision_changes():
+    state = state_with_profiles(
+        person_profile("Dimitri Volkov", "1980-01-01"),
+        person_profile("Dymitri Volkov", "1980-01-01"),
+    )
+    first = refresh_candidates(state, set(state.profiles), EntityMaintenanceConfig())
+    candidate_id = first.review_candidate_ids[0]
+    candidate = state.candidates[candidate_id]
+    candidate["status"] = "reviewed"
+    state.decisions["decision-confirmed"] = {
+        "semantic_key": candidate["semantic_key"],
+        "outcome": "same_entity",
+        "conflicts": candidate["conflicts"],
+    }
+    changed_profile = state.profiles["person:dymitri-volkov"]
+    changed_profile["revision"] = 2
+    changed_profile["fingerprint"] = "updated-fingerprint"
+
+    second = refresh_candidates(
+        state, {"person:dymitri-volkov"}, EntityMaintenanceConfig(),
+    )
+
+    assert second.review_candidate_ids == ()
+    assert second.reused_candidate_ids == (candidate_id,)
+    assert state.candidates[candidate_id]["status"] == "reviewed"

--- a/tests/test_entity_candidate_scoring.py
+++ b/tests/test_entity_candidate_scoring.py
@@ -1,0 +1,97 @@
+from src.swarm.entity_candidate_scoring import refresh_candidates
+from src.swarm.entity_maintenance_store import EntityMaintenanceConfig, EntityMaintenanceState
+
+
+def company_profile(name: str, registration: str | None = None, verified: bool = False) -> dict[str, object]:
+    profile_id = "company:" + "-".join(name.casefold().split())
+    facts: list[dict[str, object]] = [{
+        "field": "name",
+        "value": name,
+        "normalized_value": "".join(character for character in name.casefold() if character.isalnum()),
+        "source_card_id": profile_id + "-card",
+    }]
+    if registration:
+        facts.append({
+            "field": "registration_number",
+            "value": registration,
+            "normalized_value": "".join(character for character in registration.casefold() if character.isalnum()),
+            "source_card_id": profile_id + "-card",
+            "verified": verified,
+        })
+    return {
+        "profile_id": profile_id,
+        "entity_type": "company",
+        "primary_name": name,
+        "aliases": [],
+        "source_card_ids": [profile_id + "-card"],
+        "facts": facts,
+        "revision": 1,
+        "fingerprint": profile_id + "-fingerprint",
+    }
+
+
+def state_with_profiles(*profiles: str | dict[str, object]) -> EntityMaintenanceState:
+    payloads = [company_profile(profile) if isinstance(profile, str) else profile for profile in profiles]
+    return EntityMaintenanceState(profiles={str(profile["profile_id"]): profile for profile in payloads})
+
+
+def test_dirty_profile_is_compared_to_relevant_old_profile_but_not_unrelated_profile():
+    state = state_with_profiles("Northwind Ltd", "Northwind Limited", "Bluewater PLC")
+
+    summary = refresh_candidates(state, {"company:northwind-ltd"}, EntityMaintenanceConfig())
+
+    pairs = {tuple(candidate["profile_ids"]) for candidate in state.candidates.values()}
+    assert ("company:northwind-limited", "company:northwind-ltd") in pairs
+    assert all("company:bluewater-plc" not in pair for pair in pairs)
+    assert summary.new_candidate_ids
+
+
+def test_weak_lexical_candidate_stays_sidecar_only():
+    state = state_with_profiles("Alpha Logistics", "Alpine Law Office")
+
+    summary = refresh_candidates(state, set(state.profiles), EntityMaintenanceConfig())
+
+    assert summary.review_candidate_ids == ()
+    assert all(candidate["status"] == "ignored" for candidate in state.candidates.values())
+
+
+def test_verified_registration_conflict_is_review_eligible_even_below_threshold():
+    state = state_with_profiles(
+        company_profile("Zenith Trading", registration="CH-111", verified=True),
+        company_profile("Zenith Trading Limited", registration="CH-222", verified=True),
+    )
+
+    summary = refresh_candidates(state, set(state.profiles), EntityMaintenanceConfig())
+
+    candidate = state.candidates[summary.review_candidate_ids[0]]
+    assert "verified_registration_number_conflict" in candidate["conflicts"]
+    assert candidate["status"] == "pending_review"
+
+
+def test_unchanged_candidate_is_reused_without_another_review():
+    state = state_with_profiles("Northwind Ltd", "Northwind Limited")
+    first = refresh_candidates(state, set(state.profiles), EntityMaintenanceConfig())
+
+    second = refresh_candidates(state, {"company:northwind-ltd"}, EntityMaintenanceConfig())
+
+    assert first.new_candidate_ids
+    assert second.reused_candidate_ids == first.new_candidate_ids
+    assert second.review_candidate_ids == ()
+
+
+def test_conflicting_verified_values_within_one_profile_stay_pending_review():
+    profile = company_profile("Zenith Trading", registration="CH-111", verified=True)
+    profile["facts"].append({
+        "field": "registration_number",
+        "value": "CH-222",
+        "normalized_value": "ch222",
+        "source_card_id": "zenith-second-card",
+        "verified": True,
+    })
+    state = state_with_profiles(profile)
+
+    summary = refresh_candidates(state, set(state.profiles), EntityMaintenanceConfig())
+
+    candidate = state.candidates[summary.review_candidate_ids[0]]
+    assert candidate["profile_ids"] == ["company:zenith-trading"]
+    assert candidate["source_card_groups"] == [["company:zenith-trading-card"], ["zenith-second-card"]]

--- a/tests/test_entity_candidate_scoring.py
+++ b/tests/test_entity_candidate_scoring.py
@@ -35,6 +35,26 @@ def state_with_profiles(*profiles: str | dict[str, object]) -> EntityMaintenance
     return EntityMaintenanceState(profiles={str(profile["profile_id"]): profile for profile in payloads})
 
 
+def person_profile(name: str, birth_date: str) -> dict[str, object]:
+    profile_id = "person:" + "-".join(name.casefold().split())
+    return {
+        "profile_id": profile_id,
+        "entity_type": "person",
+        "primary_name": name,
+        "aliases": [],
+        "source_card_ids": [profile_id + "-card"],
+        "facts": [{
+            "field": "birth_date",
+            "value": birth_date,
+            "normalized_value": birth_date,
+            "source_card_id": profile_id + "-card",
+            "verified": True,
+        }],
+        "revision": 1,
+        "fingerprint": profile_id + "-fingerprint",
+    }
+
+
 def test_dirty_profile_is_compared_to_relevant_old_profile_but_not_unrelated_profile():
     state = state_with_profiles("Northwind Ltd", "Northwind Limited", "Bluewater PLC")
 
@@ -95,3 +115,17 @@ def test_conflicting_verified_values_within_one_profile_stay_pending_review():
     candidate = state.candidates[summary.review_candidate_ids[0]]
     assert candidate["profile_ids"] == ["company:zenith-trading"]
     assert candidate["source_card_groups"] == [["company:zenith-trading-card"], ["zenith-second-card"]]
+
+
+def test_screened_out_blocked_person_pair_with_verified_birth_conflict_is_reviewed():
+    state = state_with_profiles(
+        person_profile("Alice Smith", "1980-01-01"),
+        person_profile("Alice Jones", "1990-02-02"),
+    )
+
+    summary = refresh_candidates(state, {"person:alice-smith"}, EntityMaintenanceConfig())
+
+    candidate = state.candidates[summary.review_candidate_ids[0]]
+    assert candidate["profile_ids"] == ["person:alice-jones", "person:alice-smith"]
+    assert candidate["status"] == "pending_review"
+    assert "verified_birth_date_conflict" in candidate["conflicts"]

--- a/tests/test_entity_maintenance.py
+++ b/tests/test_entity_maintenance.py
@@ -1,5 +1,6 @@
 import json
 
+from src import swarm
 from src.swarm.blackboard import Blackboard
 from src.swarm.entity_maintenance import (
     maintenance_is_due,
@@ -9,6 +10,80 @@ from src.swarm.entity_maintenance_store import (
     EntityMaintenanceConfig,
     EntityMaintenanceState,
 )
+from src.swarm.models import Entry, EntrySource, Task, WorkerOutput
+
+
+class FakeCaller:
+    pass
+
+
+def task_with_direct_cards(metadata: dict[str, object] | None = None) -> Task:
+    return Task(
+        instruction="Resolve entity records.",
+        documents=[],
+        metadata=metadata or {},
+    )
+
+
+def patch_minimal_swarm_for_iterations(monkeypatch, *, worker_iterations: int) -> None:
+    def worker_outputs(tasks, blackboard, caller):
+        entry = Entry(
+            id=f"direct-card-{blackboard.iteration}",
+            content="Northwind Ltd is named in the task record.",
+            source=EntrySource(document="task_instruction", evidence="task record"),
+            direct_document_context=True,
+        )
+        return [WorkerOutput(
+            entries=[entry], tokens_used=0, tokens_input=0, tokens_output=0,
+            model="test", worker_id="test-worker", task={}, sections_read=[],
+        )]
+
+    monkeypatch.setattr(swarm, "_execute_initial_reading", lambda *args: ([], 0))
+    monkeypatch.setattr(swarm, "run_orchestrator", lambda *args, **kwargs: (
+        {"workers": [{}]} if args[0].iteration <= worker_iterations else {"workers": []}, 0,
+    ))
+    monkeypatch.setattr(swarm, "execute_workers_parallel", worker_outputs)
+    monkeypatch.setattr(swarm, "passes_quality_gate", lambda entry: True)
+    monkeypatch.setattr(swarm, "curate_entries", lambda *args: ([], 0))
+    monkeypatch.setattr(swarm, "synthesize_deliverable", lambda *args: ("answer", 0))
+    monkeypatch.setattr(swarm, "source_claim_verification_enabled", lambda: False)
+
+
+def test_swarm_runs_maintenance_after_iteration_three_not_each_worker_batch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        swarm,
+        "run_entity_maintenance",
+        lambda bb, caller, config, *, trigger: calls.append((bb.iteration, trigger)),
+        raising=False,
+    )
+    patch_minimal_swarm_for_iterations(monkeypatch, worker_iterations=4)
+
+    swarm.run_swarm(task_with_direct_cards(), FakeCaller(), max_iterations=4, min_iterations=4)
+
+    assert calls == [(3, "periodic"), (4, "final")]
+
+
+def test_metadata_changes_interval_without_changing_orchestrator(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        swarm,
+        "run_entity_maintenance",
+        lambda bb, caller, config, *, trigger: calls.append(
+            (bb.iteration, config.entity_resolution_interval_iterations, trigger)
+        ),
+        raising=False,
+    )
+    patch_minimal_swarm_for_iterations(monkeypatch, worker_iterations=4)
+
+    swarm.run_swarm(
+        task_with_direct_cards(metadata={"entity_resolution_interval_iterations": 2}),
+        FakeCaller(),
+        max_iterations=4,
+        min_iterations=4,
+    )
+
+    assert calls == [(2, 2, "periodic"), (4, 2, "periodic"), (4, 2, "final")]
 
 
 def _decision(outcome: str) -> dict[str, object]:

--- a/tests/test_entity_maintenance.py
+++ b/tests/test_entity_maintenance.py
@@ -5,6 +5,7 @@ from src.swarm.blackboard import Blackboard
 from src.swarm.entity_maintenance import (
     maintenance_is_due,
     project_confirmed_decisions,
+    run_entity_maintenance,
 )
 from src.swarm.entity_maintenance_store import (
     EntityMaintenanceConfig,
@@ -15,6 +16,21 @@ from src.swarm.models import Entry, EntrySource, Task, WorkerOutput
 
 class FakeCaller:
     pass
+
+
+def direct_company_card(entry_id: str) -> Entry:
+    return Entry(
+        id=entry_id,
+        content="Northwind Limited is registered as CH-7788.",
+        source=EntrySource("registry.pdf", "Registry", "Northwind Limited CH-7788"),
+        direct_document_context=True,
+        entities=[{
+            "entity_type": "company",
+            "name": "Northwind Limited",
+            "attributes": [{"kind": "registration_number", "value": "CH-7788"}],
+        }],
+        entity_annotation_provenance=[{"method": "worker"}],
+    )
 
 
 def task_with_direct_cards(metadata: dict[str, object] | None = None) -> Task:
@@ -140,3 +156,34 @@ def test_due_gate_runs_every_three_iterations_and_always_final():
         False, False, True, False, False, True,
     ]
     assert maintenance_is_due(1, config, final=True) is True
+
+
+def test_maintenance_retires_profiles_and_projections_when_all_supporting_cards_are_superseded():
+    blackboard = Blackboard(iteration=3)
+    blackboard.add_entries_batch([direct_company_card("e1"), direct_company_card("e2")])
+    config = EntityMaintenanceConfig()
+
+    run_entity_maintenance(blackboard, FakeCaller(), config, trigger="periodic")
+    profile_id = "company:northwind-limited"
+    state = blackboard.entity_maintenance_state
+    state.candidates["candidate-stale"] = {"profile_ids": [profile_id], "status": "ignored"}
+    state.decisions["decision-stale"] = {
+        "decision_id": "decision-stale",
+        "semantic_key": "company:northwind-limited",
+        "outcome": "same_entity",
+        "evidence_fingerprint": "candidate-fingerprint-stale",
+        "profile_ids": [profile_id],
+        "source_card_ids": ["e1", "e2"],
+        "rationale": "Stale conclusion.",
+        "conflicts": [],
+    }
+    project_confirmed_decisions(blackboard, state)
+    blackboard.add_entry(Entry(id="replacement", supersedes_entries=["e1", "e2"]))
+
+    run_entity_maintenance(blackboard, FakeCaller(), config, trigger="final")
+
+    assert profile_id not in state.profiles
+    assert state.candidates == {}
+    assert state.decisions == {}
+    assert blackboard.find_entry("entity-info-company-northwind-limited").status == "superseded"
+    assert blackboard.find_entry("duplicate-resolution-company:northwind-limited").status == "superseded"

--- a/tests/test_entity_maintenance.py
+++ b/tests/test_entity_maintenance.py
@@ -102,6 +102,53 @@ def test_metadata_changes_interval_without_changing_orchestrator(monkeypatch):
     assert calls == [(2, 2, "periodic"), (4, 2, "periodic"), (4, 2, "final")]
 
 
+def test_final_duplicate_decisions_are_explicit_synthesis_items_after_curation(monkeypatch):
+    captured_packet = []
+    events = []
+    patch_minimal_swarm_for_iterations(monkeypatch, worker_iterations=4)
+
+    def maintain(blackboard, caller, config, *, trigger):
+        events.append(trigger)
+        if trigger == "final":
+            blackboard.add_entry(Entry(
+                id="duplicate-resolution-dimitri-dymitri",
+                type="duplicate_name_resolution",
+                content=(
+                    '{"outcome":"same_entity","rationale":"Dmitri K. Volkov is '
+                    'VOLKOV, Dmitriy Konstantinovich."}'
+                ),
+            ))
+            blackboard.add_entry(Entry(
+                id="duplicate-resolution-nikolai-petrov",
+                type="duplicate_name_resolution",
+                content='{"outcome":"same_entity","rationale":"Nikolai V. Petrov is confirmed."}',
+            ))
+
+    def synthesize(blackboard, packet, caller):
+        captured_packet.extend(packet)
+        return "answer", 0
+
+    def curate(blackboard, caller):
+        events.append("curate")
+        return [], 0
+
+    monkeypatch.setattr(swarm, "run_entity_maintenance", maintain)
+    monkeypatch.setattr(swarm, "curate_entries", curate)
+    monkeypatch.setattr(swarm, "synthesize_deliverable", synthesize)
+
+    swarm.run_swarm(task_with_direct_cards(), FakeCaller(), max_iterations=4, min_iterations=4)
+
+    rows = [row for row in captured_packet if row["source"] == "entity_maintenance"]
+
+    assert events.index("curate") < events.index("final")
+    assert [row["entry_ids"] for row in rows] == [
+        ["duplicate-resolution-dimitri-dymitri"],
+        ["duplicate-resolution-nikolai-petrov"],
+    ]
+    assert all(row["importance"] == "critical" for row in rows)
+    assert "VOLKOV, Dmitriy Konstantinovich" in rows[0]["summary"]
+
+
 def _decision(outcome: str) -> dict[str, object]:
     return {
         "decision_id": f"decision-{outcome}",

--- a/tests/test_entity_maintenance.py
+++ b/tests/test_entity_maintenance.py
@@ -158,7 +158,7 @@ def test_due_gate_runs_every_three_iterations_and_always_final():
     assert maintenance_is_due(1, config, final=True) is True
 
 
-def test_maintenance_retires_profiles_and_projections_when_all_supporting_cards_are_superseded():
+def test_maintenance_retires_profiles_candidates_and_decisions_when_support_is_superseded():
     blackboard = Blackboard(iteration=3)
     blackboard.add_entries_batch([direct_company_card("e1"), direct_company_card("e2")])
     config = EntityMaintenanceConfig()
@@ -185,5 +185,4 @@ def test_maintenance_retires_profiles_and_projections_when_all_supporting_cards_
     assert profile_id not in state.profiles
     assert state.candidates == {}
     assert state.decisions == {}
-    assert blackboard.find_entry("entity-info-company-northwind-limited").status == "superseded"
     assert blackboard.find_entry("duplicate-resolution-company:northwind-limited").status == "superseded"

--- a/tests/test_entity_maintenance.py
+++ b/tests/test_entity_maintenance.py
@@ -1,0 +1,67 @@
+import json
+
+from src.swarm.blackboard import Blackboard
+from src.swarm.entity_maintenance import (
+    maintenance_is_due,
+    project_confirmed_decisions,
+)
+from src.swarm.entity_maintenance_store import (
+    EntityMaintenanceConfig,
+    EntityMaintenanceState,
+)
+
+
+def _decision(outcome: str) -> dict[str, object]:
+    return {
+        "decision_id": f"decision-{outcome}",
+        "semantic_key": f"company:{outcome}",
+        "outcome": outcome,
+        "evidence_fingerprint": f"candidate-fingerprint-{outcome}",
+        "profile_ids": ["company:northwind-ltd", "company:northwind-limited"],
+        "source_card_ids": ["e1", "e2"],
+        "rationale": "Source-grounded outcome.",
+        "conflicts": [],
+    }
+
+
+def same_entity_decision() -> dict[str, object]:
+    return _decision("same_entity")
+
+
+def same_name_distinct_entity_decision() -> dict[str, object]:
+    return _decision("same_name_distinct_entity")
+
+
+def uncertain_decision() -> dict[str, object]:
+    return _decision("uncertain")
+
+
+def blackboard_and_state_with_decisions(
+    *decisions: dict[str, object],
+) -> tuple[Blackboard, EntityMaintenanceState]:
+    return Blackboard(iteration=3), EntityMaintenanceState(
+        decisions={str(decision["decision_id"]): decision for decision in decisions}
+    )
+
+
+def test_only_confirmed_outcomes_create_blackboard_resolution_cards():
+    blackboard, state = blackboard_and_state_with_decisions(
+        same_entity_decision(), same_name_distinct_entity_decision(), uncertain_decision(),
+    )
+
+    project_confirmed_decisions(blackboard, state)
+
+    cards = [entry for entry in blackboard.entries if entry.type == "duplicate_name_resolution"]
+    assert {json.loads(card.content)["outcome"] for card in cards} == {
+        "same_entity", "same_name_distinct_entity",
+    }
+    assert all("uncertain" not in card.content for card in cards)
+
+
+def test_due_gate_runs_every_three_iterations_and_always_final():
+    config = EntityMaintenanceConfig()
+
+    assert [maintenance_is_due(i, config) for i in range(1, 7)] == [
+        False, False, True, False, False, True,
+    ]
+    assert maintenance_is_due(1, config, final=True) is True

--- a/tests/test_entity_maintenance_store.py
+++ b/tests/test_entity_maintenance_store.py
@@ -1,0 +1,68 @@
+import json
+
+from src.swarm.blackboard import Blackboard
+from src.swarm.entity_maintenance_store import (
+    EntityMaintenanceConfig,
+    EntityMaintenanceState,
+)
+from src.swarm.models import Entry, EntrySource
+
+
+def direct_entry(entry_id: str, content: str) -> Entry:
+    return Entry(
+        id=entry_id,
+        content=content,
+        source=EntrySource(document="agreement.pdf", section="Signature", evidence=content),
+        direct_document_context=True,
+        entities=[{"entity_type": "company", "name": "Northwind Limited"}],
+        entity_annotation_provenance=[{"method": "worker"}],
+    )
+
+
+def test_config_uses_documented_defaults_and_metadata_override():
+    assert EntityMaintenanceConfig.from_metadata({}) == EntityMaintenanceConfig(
+        entity_resolution_interval_iterations=3,
+        entity_profile_min_card_count=2,
+        duplicate_review_threshold=0.85,
+        entity_repair_max_mentions_per_card=20,
+    )
+    assert EntityMaintenanceConfig.from_metadata({
+        "entity_resolution_interval_iterations": 5,
+    }).entity_resolution_interval_iterations == 5
+
+
+def test_sidecar_round_trip_and_card_revision_watermark(tmp_path):
+    first = direct_entry("e1", "Northwind Limited signed.")
+    state = EntityMaintenanceState()
+    assert state.card_is_dirty(first)
+    state.mark_cards_processed([first])
+    state.write(str(tmp_path))
+
+    restored = EntityMaintenanceState.load(str(tmp_path))
+    assert restored.card_is_dirty(first) is False
+    first.content = "Northwind Limited signed the amended agreement."
+    assert restored.card_is_dirty(first) is True
+
+
+def test_sidecar_json_and_fingerprint_are_deterministic(tmp_path):
+    state = EntityMaintenanceState()
+    assert state.fingerprint({"b": [2, 1], "a": "x"}) == state.fingerprint({"a": "x", "b": [2, 1]})
+
+    state.profiles["northwind"] = {"name": "Northwind Limited"}
+    path = state.write(str(tmp_path))
+    first_write = path.read_bytes()
+    state.write(str(tmp_path))
+    assert path.read_bytes() == first_write
+
+
+def test_blackboard_snapshot_exposes_only_maintenance_status(tmp_path):
+    blackboard = Blackboard(output_dir=str(tmp_path))
+    blackboard.entity_maintenance_state.profiles["northwind"] = {"name": "Northwind Limited"}
+    blackboard.save_snapshot()
+
+    snapshot = json.loads((tmp_path / "swarm" / "blackboard_iter_0.json").read_text())
+    assert snapshot["entity_maintenance"] == {
+        "processed_cards": 0,
+        "profiles": 1,
+        "decisions": 0,
+    }

--- a/tests/test_entity_mention_repair.py
+++ b/tests/test_entity_mention_repair.py
@@ -2,6 +2,8 @@ from src.swarm.entity_mention_repair import (
     build_entity_catalogue,
     repair_entity_mentions,
 )
+from src.swarm.entity_maintenance_store import EntityMaintenanceState
+from src.swarm.entity_profiles import refresh_entity_profiles
 from src.swarm.models import Entry, EntrySource
 
 
@@ -56,6 +58,20 @@ def test_catalogue_includes_typed_worker_name_from_another_new_card():
     repair_entity_mentions([omitted], catalogue, 20, "run-1")
 
     assert omitted.entities == [{"entity_type": "company", "name": "Northwind Limited", "attributes": []}]
+
+
+def test_repaired_and_worker_mentions_use_one_canonical_profile_id():
+    named = direct_entry("e1", "Northwind Limited signed.")
+    named.entities = [{"entity_type": "company", "name": "Northwind Limited", "attributes": []}]
+    named.entity_annotation_provenance = [{"method": "worker"}]
+    omitted = direct_entry("e2", "Northwind Limited amended the agreement.")
+    catalogue = build_entity_catalogue([named, omitted], {})
+
+    repair_entity_mentions([omitted], catalogue, 20, "run-1")
+    state = EntityMaintenanceState()
+    refresh_entity_profiles(state, [named, omitted], min_card_count=2)
+
+    assert list(state.profiles) == ["company:northwind-limited"]
 
 
 def test_catalogue_ignores_annotation_without_worker_or_repair_provenance():

--- a/tests/test_entity_mention_repair.py
+++ b/tests/test_entity_mention_repair.py
@@ -1,0 +1,71 @@
+from src.swarm.entity_mention_repair import (
+    build_entity_catalogue,
+    repair_entity_mentions,
+)
+from src.swarm.models import Entry, EntrySource
+
+
+def direct_entry(entry_id: str, content: str, *, evidence: str | None = None) -> Entry:
+    return Entry(
+        id=entry_id,
+        content=content,
+        source=EntrySource(
+            document="agreement.pdf",
+            section="Signature",
+            evidence=content if evidence is None else evidence,
+        ),
+        direct_document_context=True,
+    )
+
+
+def profile(entity_type: str, name: str) -> dict[str, object]:
+    return {"entity_type": entity_type, "primary_name": name, "aliases": []}
+
+
+def test_repair_includes_unquoted_direct_card_and_excludes_derived_card():
+    direct = direct_entry("e1", "Maria Chen signed for Northwind Limited.", evidence="")
+    derived = Entry(id="e2", type="analysis", content="Maria Chen is material.")
+
+    result = repair_entity_mentions(
+        [direct, derived],
+        {"company:northwind-limited": profile("company", "Northwind Limited")},
+        max_mentions_per_card=20,
+        run_id="run-1",
+    )
+
+    assert result.changed_card_ids == ("e1",)
+    assert direct.entities[-1]["name"] == "Northwind Limited"
+    assert derived.entities == []
+
+
+def test_repair_uses_literal_boundaries_not_substrings():
+    card = direct_entry("e1", "The annual filing is complete.")
+
+    repair_entity_mentions([card], {"person:ann": profile("person", "Ann")}, 20, "run-1")
+
+    assert card.entities == []
+
+
+def test_catalogue_includes_typed_worker_name_from_another_new_card():
+    named = direct_entry("e1", "Northwind Limited signed.")
+    named.entities = [{"entity_type": "company", "name": "Northwind Limited", "attributes": []}]
+    omitted = direct_entry("e2", "Northwind Limited amended the agreement.")
+
+    catalogue = build_entity_catalogue([named, omitted], {})
+    repair_entity_mentions([omitted], catalogue, 20, "run-1")
+
+    assert omitted.entities == [{"entity_type": "company", "name": "Northwind Limited", "attributes": []}]
+
+
+def test_repeat_repair_is_idempotent_and_preserves_worker_annotation():
+    card = direct_entry("e1", "Maria Chen signed for Northwind Limited.")
+    card.entities = [{"entity_type": "person", "name": "Maria Chen", "attributes": []}]
+    card.entity_annotation_provenance = [{"method": "worker"}]
+    catalogue = {"company:northwind-limited": profile("company", "Northwind Limited")}
+
+    repair_entity_mentions([card], catalogue, 20, "run-1")
+    repair_entity_mentions([card], catalogue, 20, "run-2")
+
+    assert [item["name"] for item in card.entities] == ["Maria Chen", "Northwind Limited"]
+    assert card.entity_annotation_provenance[0] == {"method": "worker"}
+    assert card.entity_annotation_provenance[1]["method"] == "deterministic_repair"

--- a/tests/test_entity_mention_repair.py
+++ b/tests/test_entity_mention_repair.py
@@ -49,12 +49,40 @@ def test_repair_uses_literal_boundaries_not_substrings():
 def test_catalogue_includes_typed_worker_name_from_another_new_card():
     named = direct_entry("e1", "Northwind Limited signed.")
     named.entities = [{"entity_type": "company", "name": "Northwind Limited", "attributes": []}]
+    named.entity_annotation_provenance = [{"method": "worker"}]
     omitted = direct_entry("e2", "Northwind Limited amended the agreement.")
 
     catalogue = build_entity_catalogue([named, omitted], {})
     repair_entity_mentions([omitted], catalogue, 20, "run-1")
 
     assert omitted.entities == [{"entity_type": "company", "name": "Northwind Limited", "attributes": []}]
+
+
+def test_catalogue_ignores_annotation_without_worker_or_repair_provenance():
+    untrusted = direct_entry("e1", "Northwind Limited signed.")
+    untrusted.entities = [{"entity_type": "company", "name": "Northwind Limited", "attributes": []}]
+    untrusted.entity_annotation_provenance = [{"method": "duplicate_resolution"}]
+    omitted = direct_entry("e2", "Northwind Limited amended the agreement.")
+
+    catalogue = build_entity_catalogue([untrusted], {})
+    repair_entity_mentions([omitted], catalogue, 20, "run-1")
+
+    assert catalogue == {}
+    assert omitted.entities == []
+
+
+def test_repair_sorts_eligible_cards_by_id_for_deterministic_summary():
+    later = direct_entry("z-card", "Northwind Limited signed.")
+    earlier = direct_entry("a-card", "Northwind Limited amended the agreement.")
+
+    result = repair_entity_mentions(
+        [later, earlier],
+        {"company:northwind-limited": profile("company", "Northwind Limited")},
+        20,
+        "run-1",
+    )
+
+    assert result.changed_card_ids == ("a-card", "z-card")
 
 
 def test_repeat_repair_is_idempotent_and_preserves_worker_annotation():

--- a/tests/test_entity_profiles.py
+++ b/tests/test_entity_profiles.py
@@ -1,0 +1,148 @@
+import json
+
+from src.swarm.blackboard import Blackboard
+from src.swarm.entity_maintenance_store import EntityMaintenanceState
+from src.swarm.entity_profiles import (
+    ProfileRefreshSummary,
+    project_entity_information_cards,
+    refresh_entity_profiles,
+)
+from src.swarm.models import Entry, EntrySource
+
+
+def direct_company(entry_id: str, name: str, registration: str) -> Entry:
+    evidence = f"{name} {registration}"
+    return Entry(
+        id=entry_id,
+        content=evidence,
+        source=EntrySource("registry.pdf", "Registry", evidence),
+        direct_document_context=True,
+        entities=[{
+            "entity_type": "company",
+            "name": name,
+            "attributes": [{"kind": "registration_number", "value": registration}],
+        }],
+        entity_annotation_provenance=[{"method": "worker"}],
+    )
+
+
+def direct_person(entry_id: str, content: str, evidence: str) -> Entry:
+    return Entry(
+        id=entry_id,
+        content=content,
+        source=EntrySource("agreement.pdf", "Signature", evidence),
+        direct_document_context=True,
+        entities=[{"entity_type": "person", "name": "Maria Chen", "attributes": []}],
+        entity_annotation_provenance=[{"method": "worker"}],
+    )
+
+
+def clone_direct(entry: Entry, entry_id: str) -> Entry:
+    return Entry(
+        id=entry_id,
+        content=entry.content,
+        source=entry.source,
+        direct_document_context=True,
+        entities=entry.entities,
+        entity_annotation_provenance=entry.entity_annotation_provenance,
+    )
+
+
+def blackboard_with_profile(name: str) -> tuple[Blackboard, EntityMaintenanceState]:
+    blackboard = Blackboard(iteration=4)
+    state = EntityMaintenanceState(profiles={
+        "company:northwind-limited": {
+            "profile_id": "company:northwind-limited",
+            "entity_type": "company",
+            "primary_name": name,
+            "aliases": [],
+            "source_card_ids": ["e1", "e2"],
+            "facts": [],
+            "revision": 1,
+            "fingerprint": "profile_fp_0123456789abcdef",
+        },
+    })
+    return blackboard, state
+
+
+def changed(profile_id: str) -> ProfileRefreshSummary:
+    return ProfileRefreshSummary(dirty_profile_ids=(profile_id,))
+
+
+def unchanged() -> ProfileRefreshSummary:
+    return ProfileRefreshSummary()
+
+
+def test_profile_requires_two_direct_cards_and_keeps_conflicting_values():
+    first = direct_company("e1", "Northwind Limited", "CH-7788")
+    second = direct_company("e2", "Northwind Limited", "CH-9999")
+    state = EntityMaintenanceState()
+
+    assert refresh_entity_profiles(state, [first], min_card_count=2).created_profile_ids == ()
+    summary = refresh_entity_profiles(state, [first, second], min_card_count=2)
+    profile = state.profiles[summary.created_profile_ids[0]]
+
+    assert {fact["value"] for fact in profile["facts"] if fact["field"] == "registration_number"} == {"CH-7788", "CH-9999"}
+
+
+def test_profile_fact_records_direct_worker_context_without_quote():
+    entry = direct_person("e1", "Maria Chen signed for Northwind.", evidence="")
+    entry.entities = [{"entity_type": "person", "name": "Maria Chen", "attributes": []}]
+    state = EntityMaintenanceState()
+    summary = refresh_entity_profiles(state, [entry, clone_direct(entry, "e2")], min_card_count=2)
+
+    assert state.profiles[summary.created_profile_ids[0]]["facts"][0]["provenance_quality"] == "direct_worker_context"
+
+
+def test_project_updates_one_current_entity_information_card_only_on_change():
+    blackboard, state = blackboard_with_profile("Northwind Limited")
+    first_ids = project_entity_information_cards(blackboard, state, changed("company:northwind-limited"))
+    second_ids = project_entity_information_cards(blackboard, state, unchanged())
+
+    assert first_ids == ("entity-info-company-northwind-limited",)
+    assert second_ids == ()
+    assert len([entry for entry in blackboard.entries if entry.type == "entity_information"]) == 1
+
+
+def test_refresh_is_deterministic_and_only_revisions_changed_payloads():
+    first = direct_company("e2", "Northwind Limited", "CH-9999")
+    second = direct_company("e1", "Northwind Limited", "CH-7788")
+    state = EntityMaintenanceState()
+
+    created = refresh_entity_profiles(state, [first, second], min_card_count=2)
+    profile = state.profiles[created.created_profile_ids[0]]
+    unchanged_summary = refresh_entity_profiles(state, [second, first], min_card_count=2)
+
+    assert profile["source_card_ids"] == ["e1", "e2"]
+    assert profile["revision"] == 1
+    assert unchanged_summary == ProfileRefreshSummary()
+
+
+def test_projected_card_is_compact_json_and_replaces_existing_current_card():
+    blackboard, state = blackboard_with_profile("Northwind Limited")
+    state.profiles["company:northwind-limited"]["aliases"] = ["Northwind Ltd"]
+    state.profiles["company:northwind-limited"]["facts"] = [{
+        "field": "registration_number",
+        "value": "CH-7788",
+        "normalized_value": "ch7788",
+        "source_card_id": "e1",
+        "source_document": "registry.pdf",
+        "source_section": "Registry",
+        "quote": "Northwind Limited CH-7788",
+        "provenance_quality": "quoted_direct",
+        "status": "observed",
+    }]
+
+    project_entity_information_cards(blackboard, state, changed("company:northwind-limited"))
+    projected = blackboard.find_entry("entity-info-company-northwind-limited")
+
+    assert projected is not None
+    assert projected.source is None
+    assert projected.created_by.worker_id == "entity_maintenance"
+    assert json.loads(projected.content) == {
+        "aliases": ["Northwind Ltd"],
+        "facts": {"registration_number": ["CH-7788"]},
+        "primary_name": "Northwind Limited",
+        "profile_id": "company:northwind-limited",
+        "revision": 1,
+    }

--- a/tests/test_entity_profiles.py
+++ b/tests/test_entity_profiles.py
@@ -1,10 +1,6 @@
-import json
-
-from src.swarm.blackboard import Blackboard
 from src.swarm.entity_maintenance_store import EntityMaintenanceState
 from src.swarm.entity_profiles import (
     ProfileRefreshSummary,
-    project_entity_information_cards,
     refresh_entity_profiles,
 )
 from src.swarm.models import Entry, EntrySource
@@ -46,31 +42,6 @@ def clone_direct(entry: Entry, entry_id: str) -> Entry:
         entities=entry.entities,
         entity_annotation_provenance=entry.entity_annotation_provenance,
     )
-
-
-def blackboard_with_profile(name: str) -> tuple[Blackboard, EntityMaintenanceState]:
-    blackboard = Blackboard(iteration=4)
-    state = EntityMaintenanceState(profiles={
-        "company:northwind-limited": {
-            "profile_id": "company:northwind-limited",
-            "entity_type": "company",
-            "primary_name": name,
-            "aliases": [],
-            "source_card_ids": ["e1", "e2"],
-            "facts": [],
-            "revision": 1,
-            "fingerprint": "profile_fp_0123456789abcdef",
-        },
-    })
-    return blackboard, state
-
-
-def changed(profile_id: str) -> ProfileRefreshSummary:
-    return ProfileRefreshSummary(dirty_profile_ids=(profile_id,))
-
-
-def unchanged() -> ProfileRefreshSummary:
-    return ProfileRefreshSummary()
 
 
 def test_profile_requires_two_direct_cards_and_keeps_conflicting_values():
@@ -138,16 +109,6 @@ def test_profile_preserves_verified_attribute_qualifiers_deterministically():
     assert repeated == ProfileRefreshSummary()
 
 
-def test_project_updates_one_current_entity_information_card_only_on_change():
-    blackboard, state = blackboard_with_profile("Northwind Limited")
-    first_ids = project_entity_information_cards(blackboard, state, changed("company:northwind-limited"))
-    second_ids = project_entity_information_cards(blackboard, state, unchanged())
-
-    assert first_ids == ("entity-info-company-northwind-limited",)
-    assert second_ids == ()
-    assert len([entry for entry in blackboard.entries if entry.type == "entity_information"]) == 1
-
-
 def test_refresh_is_deterministic_and_only_revisions_changed_payloads():
     first = direct_company("e2", "Northwind Limited", "CH-9999")
     second = direct_company("e1", "Northwind Limited", "CH-7788")
@@ -160,33 +121,3 @@ def test_refresh_is_deterministic_and_only_revisions_changed_payloads():
     assert profile["source_card_ids"] == ["e1", "e2"]
     assert profile["revision"] == 1
     assert unchanged_summary == ProfileRefreshSummary()
-
-
-def test_projected_card_is_compact_json_and_replaces_existing_current_card():
-    blackboard, state = blackboard_with_profile("Northwind Limited")
-    state.profiles["company:northwind-limited"]["aliases"] = ["Northwind Ltd"]
-    state.profiles["company:northwind-limited"]["facts"] = [{
-        "field": "registration_number",
-        "value": "CH-7788",
-        "normalized_value": "ch7788",
-        "source_card_id": "e1",
-        "source_document": "registry.pdf",
-        "source_section": "Registry",
-        "quote": "Northwind Limited CH-7788",
-        "provenance_quality": "quoted_direct",
-        "status": "observed",
-    }]
-
-    project_entity_information_cards(blackboard, state, changed("company:northwind-limited"))
-    projected = blackboard.find_entry("entity-info-company-northwind-limited")
-
-    assert projected is not None
-    assert projected.source is None
-    assert projected.created_by.worker_id == "entity_maintenance"
-    assert json.loads(projected.content) == {
-        "aliases": ["Northwind Ltd"],
-        "facts": {"registration_number": ["CH-7788"]},
-        "primary_name": "Northwind Limited",
-        "profile_id": "company:northwind-limited",
-        "revision": 1,
-    }

--- a/tests/test_entity_profiles.py
+++ b/tests/test_entity_profiles.py
@@ -94,6 +94,50 @@ def test_profile_fact_records_direct_worker_context_without_quote():
     assert state.profiles[summary.created_profile_ids[0]]["facts"][0]["provenance_quality"] == "direct_worker_context"
 
 
+def test_profile_preserves_verified_attribute_qualifiers_deterministically():
+    first = direct_person("e2", "Maria Chen presented her passport.", "Maria Chen passport P-123")
+    first.entities[0]["attributes"] = [{
+        "kind": "government_id",
+        "value": "P-123",
+        "verified": True,
+        "qualifiers": {"issuer": "CH", "identifier_type": "passport"},
+    }]
+    second = clone_direct(first, "e1")
+    state = EntityMaintenanceState()
+
+    created = refresh_entity_profiles(state, [first, second], min_card_count=2)
+    profile = state.profiles[created.created_profile_ids[0]]
+    facts = [fact for fact in profile["facts"] if fact["field"] == "government_id"]
+    repeated = refresh_entity_profiles(state, [second, first], min_card_count=2)
+
+    assert facts == [{
+        "field": "government_id",
+        "value": "P-123",
+        "normalized_value": "p123",
+        "source_card_id": "e1",
+        "source_document": "agreement.pdf",
+        "source_section": "Signature",
+        "quote": "Maria Chen passport P-123",
+        "provenance_quality": "quoted_direct",
+        "status": "observed",
+        "verified": True,
+        "qualifiers": {"identifier_type": "passport", "issuer": "CH"},
+    }, {
+        "field": "government_id",
+        "value": "P-123",
+        "normalized_value": "p123",
+        "source_card_id": "e2",
+        "source_document": "agreement.pdf",
+        "source_section": "Signature",
+        "quote": "Maria Chen passport P-123",
+        "provenance_quality": "quoted_direct",
+        "status": "observed",
+        "verified": True,
+        "qualifiers": {"identifier_type": "passport", "issuer": "CH"},
+    }]
+    assert repeated == ProfileRefreshSummary()
+
+
 def test_project_updates_one_current_entity_information_card_only_on_change():
     blackboard, state = blackboard_with_profile("Northwind Limited")
     first_ids = project_entity_information_cards(blackboard, state, changed("company:northwind-limited"))

--- a/tests/test_entity_resolution_core.py
+++ b/tests/test_entity_resolution_core.py
@@ -1,0 +1,65 @@
+from src.entity_resolution import (
+    CompanyRecord,
+    PersonAttribute,
+    PersonRecord,
+    resolve_companies,
+    resolve_people,
+)
+
+
+def test_company_registration_match_merges_while_conflict_stays_reviewable():
+    result = resolve_companies([
+        CompanyRecord(
+            "company-a",
+            "Zenith Petrochem Industries LLC",
+            "invoice.docx",
+            metadata={"registration_number": "AE-123", "address": "Jebel Ali"},
+        ),
+        CompanyRecord(
+            "company-b",
+            "Zenith Petrochemical Industries LLC",
+            "kyc.docx",
+            metadata={"registration_number": "AE-123", "address": "Jebel Ali"},
+        ),
+        CompanyRecord(
+            "company-c",
+            "Zenith Petroleum Industries FZE",
+            "screening.docx",
+            metadata={"registration_number": "AE-999"},
+        ),
+    ])
+
+    assert {report.status for report in result.duplicate_name_reports} == {
+        "auto_merged",
+        "review_required",
+    }
+    assert not any(
+        "company-c" in cluster.member_record_ids for cluster in result.clusters
+    )
+
+
+def test_person_matching_verified_issuer_qualified_id_merges_without_conflicts():
+    identifier = {
+        "kind": "government_id",
+        "value": "CH-123",
+        "verified": True,
+        "qualifiers": (("identifier_type", "passport"), ("issuer", "CH")),
+    }
+    result = resolve_people([
+        PersonRecord(
+            "person-a",
+            "Maria Chen",
+            "passport.pdf",
+            attributes=(PersonAttribute(source_document_id="passport.pdf", **identifier),),
+        ),
+        PersonRecord(
+            "person-b",
+            "Chen, Maria",
+            "kyc.pdf",
+            attributes=(PersonAttribute(source_document_id="kyc.pdf", **identifier),),
+        ),
+    ])
+
+    assert len(result.confirmed_profiles) == 1
+    assert result.confirmed_profiles[0].member_record_ids == ("person-a", "person-b")
+    assert result.uncertain_connections == ()

--- a/tests/test_entity_resolution_documentation.py
+++ b/tests/test_entity_resolution_documentation.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_readme_documents_periodic_entity_maintenance_contract():
+    readme = Path("README.md").read_text(encoding="utf-8")
+    for required in (
+        "entity_resolution_interval_iterations",
+        "duplicate_review_threshold",
+        "entity_profile_min_card_count",
+        "entity_repair_max_mentions_per_card",
+        "swarm/entity_resolution/state.json",
+        "entity_information",
+        "duplicate_name_resolution",
+        "direct-document-worker",
+    ):
+        assert required in readme

--- a/tests/test_entity_resolution_documentation.py
+++ b/tests/test_entity_resolution_documentation.py
@@ -9,7 +9,6 @@ def test_readme_documents_periodic_entity_maintenance_contract():
         "entity_profile_min_card_count",
         "entity_repair_max_mentions_per_card",
         "swarm/entity_resolution/state.json",
-        "entity_information",
         "duplicate_name_resolution",
         "direct-document-worker",
     ):

--- a/tests/test_entity_specialist_review.py
+++ b/tests/test_entity_specialist_review.py
@@ -1,0 +1,103 @@
+import json
+
+from src.swarm.entity_maintenance_store import EntityMaintenanceState
+from src.swarm.entity_specialist_review import review_pending_candidates
+from src.swarm.models import ModelResult
+
+
+class FakeCaller:
+    def __init__(self, responses: list[dict[str, object]]):
+        self.responses = list(responses)
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str, *, max_tokens: int = 8192,
+                 temperature: float = 0.05, json_mode: bool = True) -> ModelResult:
+        self.prompts.append(prompt)
+        return ModelResult(
+            text=json.dumps(self.responses.pop(0)),
+            tokens_input=10,
+            tokens_output=5,
+            tokens_total=15,
+            model="fake-model",
+            latency_ms=1,
+        )
+
+
+class FailingCaller:
+    def complete(self, prompt: str, **_: object) -> ModelResult:
+        raise RuntimeError("provider unavailable")
+
+
+def state_with_pending_candidate() -> EntityMaintenanceState:
+    profiles = {
+        "company:northwind-ltd": {
+            "profile_id": "company:northwind-ltd",
+            "entity_type": "company",
+            "primary_name": "Northwind Ltd",
+            "aliases": [],
+            "source_card_ids": ["e1"],
+            "facts": [{
+                "field": "registration_number",
+                "value": "CH-7788",
+                "source_card_id": "e1",
+                "quote": "Northwind Ltd registration CH-7788",
+                "verified": True,
+                "qualifiers": {},
+            }],
+        },
+        "company:northwind-limited": {
+            "profile_id": "company:northwind-limited",
+            "entity_type": "company",
+            "primary_name": "Northwind Limited",
+            "aliases": [],
+            "source_card_ids": ["e2"],
+            "facts": [{
+                "field": "registration_number",
+                "value": "CH-7788",
+                "source_card_id": "e2",
+                "quote": "Northwind Limited registration CH-7788",
+                "verified": True,
+                "qualifiers": {},
+            }],
+        },
+    }
+    candidate = {
+        "candidate_id": "candidate_northwind",
+        "semantic_key": "company:company:northwind-limited|company:northwind-ltd",
+        "evidence_fingerprint": "candidate_fp_northwind",
+        "profile_ids": ["company:northwind-ltd", "company:northwind-limited"],
+        "source_card_groups": [["e1"], ["e2"]],
+        "score": 0.99,
+        "evidence": ["exact_name", "same_registration_number"],
+        "conflicts": [],
+        "status": "pending_review",
+    }
+    return EntityMaintenanceState(profiles=profiles, candidates={"candidate_northwind": candidate})
+
+
+def test_specialist_makes_one_call_and_accepts_same_entity_with_source_citations():
+    state = state_with_pending_candidate()
+    caller = FakeCaller([{
+        "decision": "same_entity",
+        "rationale": "The same registration appears on both source cards.",
+        "citations": [
+            {"source_card_id": "e1", "quote": "CH-7788"},
+            {"source_card_id": "e2", "quote": "CH-7788"},
+        ],
+    }])
+
+    summary = review_pending_candidates(state, tuple(state.candidates), caller)
+
+    assert summary.model_calls == 1
+    assert state.decisions[next(iter(state.decisions))]["outcome"] == "same_entity"
+
+
+def test_uncertain_and_transport_failure_remain_sidecar_only_for_retry():
+    state = state_with_pending_candidate()
+    caller = FailingCaller()
+
+    summary = review_pending_candidates(state, tuple(state.candidates), caller)
+
+    assert summary.model_calls == 1
+    assert state.candidates[next(iter(state.candidates))]["status"] == "review_retry"
+    assert state.decisions == {}

--- a/tests/test_gemini_rate_limit.py
+++ b/tests/test_gemini_rate_limit.py
@@ -1,0 +1,14 @@
+import pytest
+
+from src.providers.gemini import _RequestLimiter
+
+
+def test_request_limiter_uses_the_configured_requests_per_minute():
+    limiter = _RequestLimiter(10)
+
+    assert limiter.interval == pytest.approx(6.0)
+
+
+def test_request_limiter_rejects_non_positive_rate():
+    with pytest.raises(ValueError, match="requests_per_minute must be positive"):
+        _RequestLimiter(0)


### PR DESCRIPTION
## Summary

- Resolve duplicate names found in the example input documents.
- Use Python-based normalization and candidate scoring to identify possible duplicate references, including cases where similar names may belong to different entities.
- Use a specialized review agent to decide whether candidates represent the same entity based only on evidence collected from the input documents.
- Preserve provenance while repairing and reconciling entity references.
- Reduce token usage while maintaining comparable benchmark results.

## Duplicate-name decisions from the input documents

The latest final blackboard contains three explicit `duplicate_name_resolution` decisions based on evidence extracted from the example's input documents:

1. **Zenith Petrochem Industries LLC** and **Zenith Petrochemical Industries LLC** were resolved as the same entity. The commercial invoice uses the first name, while the LC application uses the second. Both documents identify the same Plot C-47, Jebel Ali Free Zone, Dubai address and JAFZA license `JAFZA-2019-08771`.

2. **Nikolai V. Petrov** and **Nikolai Vladimirovich Petrov** were kept as distinct entities. The KYC document gives Nikolai V. Petrov a birth date of September 22, 1975, while the screening document gives Nikolai Vladimirovich Petrov a birth date of March 15, 1968. The name similarity was therefore outweighed by the conflicting birth dates.

3. **Dmitri K. Volkov** and **VOLKOV, Dmitriy Konstantinovich** were resolved as the same entity. The screening document reports the same date of birth, June 8, 1971, for both name forms.

## Evaluation

The comparison uses the `international-trade-sanctions/extract-transaction-entity-details` task.

| Run | Model configuration | Score | Total tokens | Estimated cost |
|---|---|---:|---:|---:|
| GitHub example baseline | Gemini 3.1 Flash-lite scorer | **80/85** | 1,229,456 | $1.0232 |
| Original stateful swarm (rerun with Gemini 3.1 Flash-lite) | Gemini 3.1 Flash-lite worker and scorer | **74/85** | 1,651,431 | $0.5838 |
| Current duplicate-name-resolution, 2026-08-15 | Gemini 3.1 Flash-lite worker and scorer | **74/85** | 1,242,251 | $0.4355 |

The current duplicate-name-resolution version achieved the same 74/85 score as the modified API version while using 409,180 fewer tokens and costing $0.1483 less.

Scores are stochastic. Repeated runs with the same Gemini 3.1 Flash-lite model and task inputs varied by up to three criteria points in the observed reruns, ranging from 72/85 to 75/85. Small score differences should therefore not be over-interpreted.

## Testing

All tests passed (run locally).
