### PR TITLE
Fix : pass usedforsecurity=False to hashlib.md5 calls

### DIFF
--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -33,7 +33,7 @@ def ingest_file(path: Path) -> Document:
     suffix = path.suffix.lower()
     name = path.name
     size_bytes = path.stat().st_size
-    doc_id = f"doc_{hashlib.md5(name.encode()).hexdigest()[:8]}"
+    doc_id = f"doc_{hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:8]}"
 
     reader = _READERS.get(suffix, read_text)
     text, structured = reader(path)
@@ -52,7 +52,7 @@ def _make_lazy_doc(path: Path) -> Document:
     suffix = path.suffix.lower()
     name = path.name
     size_bytes = path.stat().st_size
-    doc_id = f"doc_{hashlib.md5(name.encode()).hexdigest()[:8]}"
+    doc_id = f"doc_{hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:8]}"
     reader = _READERS.get(suffix, read_text)
 
     def _load():

--- a/src/loop/actions.py
+++ b/src/loop/actions.py
@@ -256,7 +256,7 @@ def _run_search(action: dict, board: Board, caller) -> dict:
         return {}
 
     src = Source(
-        id=f"web_{hashlib.md5(query.encode()).hexdigest()[:8]}",
+        id=f"web_{hashlib.md5(query.encode(), usedforsecurity=False).hexdigest()[:8]}",
         name=f"web: {query[:60]}", kind="web",
         read_status="read", relevance="definite",
         relevance_reason="fetched for query",


### PR DESCRIPTION
Ran a quick Bandit security pass across the codebase and noticed a few B324 warnings for "hashlib.md5()"

Because these hashes are just used to generate short IDs for ingested docs and action queries rather than for anything security-sensitive, I added `usedforsecurity=False` to the calls. This clears the scanner warnings and prevents crashes on systems running with FIPS mode enabled.

Files changed:
* `src/ingestion/__init__.py`
* `src/loop/actions.py`

Tested locally with Bandit to confirm the warnings are resolved.