### PR TITLE
fix(ingestion) : guard pandoc subprocess call against CLI argument injection

### DIFF
--- a/src/ingestion/docx.py
+++ b/src/ingestion/docx.py
@@ -10,8 +10,9 @@ def read_docx(path: Path) -> tuple[str, dict]:
     if not pandoc:
         return _read_docx_fallback(path), {}
 
+    safe_path = str(path.resolve())
     result = subprocess.run(
-        [pandoc, str(path), "-t", "markdown", "--wrap=none", "--track-changes=accept"],
+        [pandoc, "-t", "markdown", "--wrap=none", "--track-changes=accept", "--", safe_path],
         capture_output=True, text=True, timeout=30,
         encoding="utf-8", errors="replace",
     )


### PR DESCRIPTION
- Summary of Changes

While reviewing document ingestion in `src/ingestion/docx.py`, I noticed that `subprocess.run` passes the input document path as a positional argument directly alongside CLI flags.

If an untrusted or dynamically fetched filename starts with leading hyphens (e.g., `--output=...` or flags targeting pandoc's engine), the subprocess CLI parser can mistake the filename for a command option rather than an input file.

- What Was Done

1. **End-of-Options Demarcation:** Added `--` right before the target file path to ensure pandoc treats subsequent tokens strictly as positional files.
2. **Path Normalization:** Explicitly resolved `path.resolve()` before passing it into the argument list to prevent relative dash-prefixed paths from altering command behavior.
3. **Flag Reordering:** Grouped all pandoc configuration flags (`-t markdown`, `--wrap=none`, `--track-changes=accept`) prior to the delimiter.

Tested locally against standard `.docx` files to ensure normal markdown conversion behavior remains unchanged.